### PR TITLE
Support eBPF and TUN coexistence with route exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ listeners:
     shared:
       interface: [br0]        # 换成你的下联网卡名
 
-# 用 eBPF 就不要再开 TUN，两者会打架，见下面「注意事项」
+# TUN 可以一起开，见下面「和 TUN 共存」。只用 eBPF 的话关掉就行
 tun:
   enable: false
 ```
@@ -86,20 +86,47 @@ listeners:
 
 ## 注意事项（这几条不看会踩坑）
 
-**必须关掉 TUN。** 这条最重要。TUN 的 `auto-route` 会装一条策略路由，把转发流量整个抓进 TUN 设备。这条规则在 eBPF 之后生效，结果就是：你配了 `bypass-rule-set`，包也确实被 eBPF 放行了，但转头就被策略路由捞进 TUN 又送回 mihomo——白配，而且国内网站会直接不通。
-
-已经有 eBPF 了就不需要 TUN，直接：
-
-```yaml
-tun:
-  enable: false
-```
-
 **DNS 永远走核心，不受 bypass 影响。** `dns-mode: hijack` 时所有 53 端口的流量无条件劫持进核心，内核里对端口 53 的判断排在所有 CIDR 判断之前。所以基于 DNS 的广告拦截（`nameserver-policy` 里配 `rcode://success` 那种）照常工作，不会因为开了 CN IP 直连就失效。
+
+**fake-ip 段永远不会被放行。** fake IP 只对核心有意义，所以内核里对 fake-ip 段的判断优先于所有 bypass 判断——就算你把 `fake-ip-range` 设成 `100.64.0.0/10`（落在私网表里），这些地址也照样进核心。改了 `fake-ip-range` 热重载即可生效，不用重启。
 
 **只有 `behavior: ipcidr` 的规则集会被采纳。** 写成 `domain` 不会报错，会被安静地跳过，然后你会以为没生效。
 
 **下联网卡要填对。** `shared.interface` 填的是下联那张卡（热点是 `wlan0`、桥接是 `br0`），填成上联网卡不会生效。
+
+## 和 TUN 共存
+
+以前这里写的是「必须关掉 TUN」，原因是：eBPF 的放行只发生在 socket 层，包该走的路由一点没变；而 TUN 的 `auto-route` 会把路由表整个指向 TUN 设备。于是你配了 `bypass-rule-set`，包确实被内核放行了，转头又被策略路由捞进 TUN 送回核心——白配，而且这些地址在规则里往往没有对应的直连规则，会被丢给远端代理，表现就是国内网站直接不通。
+
+现在两边可以一起开，靠两个机制，按集合大小分工：
+
+**私网地址走路由排除。** 开着 `bypass-private-address: true`（默认）时，eBPF 入站启动后会把私网网段（`10/8`、`172.16/12`、`192.168/16`、`100.64/10`、`169.254/16`、`fc00::/7`、`fe80::/10`）报给 TUN，TUN 建设备时就把它们从 auto-route 的路由集合里摘掉。这些流量根本不进 TUN，是真正的直连。fake-ip 段和 TUN 自己的地址会被排除在外——它们必须留在 TUN 的路由里。启动日志里能看到：
+
+```
+[TUN] keeping 7 prefix(es) off auto-route so the eBPF inbound bypass stays direct: 10.0.0.0/8, ...
+```
+
+**`bypass-rule-set` 走到达即直连。** 规则集不能用路由排除：它要等 rule-provider 加载完才知道内容，而那已经是 TUN 建完设备之后了；而且 `cn.mrs` 这种上万条前缀灌进路由表也不现实。所以走另一条路——这些目标被 TUN 抓进来之后，不进规则引擎，直接按直连处理（`bypass-tun-direct`，默认开）。代价是多一次用户态转发，比不通好，也比让规则把它丢给代理好。想彻底零开销就还是别开 TUN，或者把这些网段手写进 `tun.route-exclude-address`。
+
+不想要这个行为（比如你就是故意放行某些网段交给 TUN 处理）就关掉它：
+
+```yaml
+listeners:
+  - name: ebpf-in
+    type: ebpf
+    bypass-tun-direct: false
+```
+
+关掉之后，被 TUN 接管的 bypass 网段会在日志里报出来，让你自己决定怎么处理：
+
+```
+[EBPF] TUN auto-route claims 3 destination prefix(es) the eBPF inbound bypasses (...)
+```
+
+还有两条和 TUN 同开时要注意：
+
+- **`strict-route: true` 建议关掉。** 它会重排策略路由并阻断绕过 TUN 的流量，和 eBPF 的 lo 重定向、核心自己的直连出站都可能互斥。
+- **同一张网卡上不要同时开 `shared` 和 TUN 的 `auto-redirect`。** eBPF 在 TC ingress（netfilter 之前）改写目的地址，`auto-redirect` 是 nftables prerouting，两套透明代理叠在一张网卡上顺序难保证。用 `shared.interface` 和 TUN 的 `include-interface` / `exclude-interface` 把网卡分开。
 
 ## 完整参数表
 
@@ -136,6 +163,10 @@ listeners:
     # 是否放行私网地址（10/8、192.168/16 等），默认 true
     # 做旁路网关时通常设 false，否则下联互访会被放行、拿不到统计
     bypass-private-address: false
+
+    # TUN 也开着时，被 TUN 的 auto-route 抓进来的 bypass 目标是否直接直连，
+    # 不再进规则引擎。默认 true。见上面「和 TUN 共存」
+    bypass-tun-direct: true
 
     # ---- local：本机进程 ----
     local:
@@ -290,9 +321,9 @@ proxies:
 
 ## 如果你还在用 TUN
 
-用 eBPF 就不需要 TUN 了，可以跳过这一节。
+只用 eBPF 的话可以跳过这一节；TUN 和 eBPF 一起开见上面「和 TUN 共存」。
 
-仍然用 TUN 的话，Tailscale 的 magicsock 会有一个问题：它的 UDP socket 出站源地址不定，会被 TUN 的 auto-route 策略路由抓走，导致 magicsock 流量绕回 mihomo 自己。两种解法选一个：
+用 TUN 的话，Tailscale 的 magicsock 会有一个问题：它的 UDP socket 出站源地址不定，会被 TUN 的 auto-route 策略路由抓走，导致 magicsock 流量绕回 mihomo 自己。两种解法选一个：
 
 ```yaml
 # 解法一：固定端口 + sing-tun 原生豁免（推荐，纯配置）
@@ -385,7 +416,7 @@ listeners:
       interface: [br0]
       ipv6-mode: always
 
-# 用 eBPF 就别开 TUN
+# 只用 eBPF 的话关掉 TUN；一起开见「和 TUN 共存」
 tun:
   enable: false
 

--- a/common/ebpf/cgroup_fakeip.go
+++ b/common/ebpf/cgroup_fakeip.go
@@ -1,0 +1,110 @@
+//go:build with_ebpf && (linux || android)
+
+package ebpf
+
+import (
+	"errors"
+	"net/netip"
+	"unsafe"
+
+	E "github.com/metacubex/sing/common/exceptions"
+
+	"golang.org/x/sys/unix"
+)
+
+// SetFakeIPRanges replaces the fake-ip ranges the packet program uses to force
+// interception, and reports whether anything changed.
+//
+// The ranges come from the DNS configuration. That is applied before the
+// inbound starts on a cold start, but it can also change under a running
+// inbound when a config reload leaves the listener itself untouched. Without a
+// runtime path the control record would keep whatever range the process
+// started with, and a fake-ip range that sits inside a bypassed range
+// (100.64.0.0/10, say) would have every fake address bypassed instead of
+// proxied.
+func (b *CgroupBackend) SetFakeIPRanges(ipv4 netip.Prefix, ipv6 netip.Prefix) (bool, error) {
+	if b == nil {
+		return false, errBackendClosed
+	}
+	normalizedIPv4, err := normalizeAddressPrefix("IPv4 FakeIP range", ipv4, true)
+	if err != nil {
+		return false, err
+	}
+	normalizedIPv6, err := normalizeAddressPrefix("IPv6 FakeIP range", ipv6, false)
+	if err != nil {
+		return false, err
+	}
+	b.access.Lock()
+	defer b.access.Unlock()
+	if err = b.health.requireUsable(b.runtime != nil); err != nil {
+		return false, err
+	}
+	if normalizedIPv4 == b.fakeIPIPv4 && normalizedIPv6 == b.fakeIPIPv6 {
+		return false, nil
+	}
+	previousIPv4, previousIPv6 := b.fakeIPIPv4, b.fakeIPIPv6
+	b.fakeIPIPv4 = normalizedIPv4
+	b.fakeIPIPv6 = normalizedIPv6
+	if err = b.mutateCgroupControlLocked(b.applyFakeIPControlLocked); err != nil {
+		b.fakeIPIPv4 = previousIPv4
+		b.fakeIPIPv6 = previousIPv6
+		return false, err
+	}
+	return true, nil
+}
+
+// FakeIPRanges reports the ranges currently compiled into the control record.
+func (b *CgroupBackend) FakeIPRanges() (netip.Prefix, netip.Prefix) {
+	if b == nil {
+		return netip.Prefix{}, netip.Prefix{}
+	}
+	b.access.RLock()
+	defer b.access.RUnlock()
+	return b.fakeIPIPv4, b.fakeIPIPv6
+}
+
+func (b *CgroupBackend) applyFakeIPControlLocked(control *cgroupControl) {
+	control.Flags &^= cgroupFlagFakeIPIPv4 | cgroupFlagFakeIPIPv6
+	control.FakeIPIPv4Prefix = [4]byte{}
+	control.FakeIPIPv4Mask = [4]byte{}
+	control.FakeIPIPv6Prefix = [16]byte{}
+	control.FakeIPIPv6Mask = [16]byte{}
+	if b.fakeIPIPv4.IsValid() {
+		control.Flags |= cgroupFlagFakeIPIPv4
+		control.FakeIPIPv4Prefix = b.fakeIPIPv4.Addr().As4()
+		control.FakeIPIPv4Mask = prefixMask4(b.fakeIPIPv4.Bits())
+	}
+	if b.fakeIPIPv6.IsValid() {
+		control.Flags |= cgroupFlagFakeIPIPv6
+		control.FakeIPIPv6Prefix = b.fakeIPIPv6.Addr().As16()
+		control.FakeIPIPv6Mask = prefixMask16(b.fakeIPIPv6.Bits())
+	}
+}
+
+// mutateCgroupControlLocked applies an in-place change to the live control
+// record. Only load time knows the listener port and the self-bypass TGID, so a
+// runtime change has to read the record back instead of rebuilding it. A
+// missing record means the programs are not loaded yet and loadPrograms will
+// write the new value itself.
+func (b *CgroupBackend) mutateCgroupControlLocked(mutate func(*cgroupControl)) error {
+	if b.runtime == nil {
+		return errBackendClosed
+	}
+	if b.runtime.control_map_fd <= 0 {
+		return nil
+	}
+	key := uint32(0)
+	var control cgroupControl
+	if err := lookupMap(b.runtime.control_map_fd, unsafe.Pointer(&key), unsafe.Pointer(&control)); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil
+		}
+		return E.Cause(err, "read eBPF cgroup control map")
+	}
+	previous := control
+	mutate(&control)
+	if control == previous {
+		return nil
+	}
+	return updateMap(b.runtime.control_map_fd, unsafe.Pointer(&key), unsafe.Pointer(&control))
+}

--- a/common/ebpf/cgroup_fakeip_test.go
+++ b/common/ebpf/cgroup_fakeip_test.go
@@ -1,0 +1,86 @@
+//go:build with_ebpf && (linux || android)
+
+package ebpf
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// The control record is read back and mutated in place at runtime, so the
+// fake-ip fields have to be cleared before they are rewritten and every
+// unrelated flag has to survive. Getting this wrong either strands a stale
+// range in the kernel or drops an unrelated policy bit.
+func TestApplyFakeIPControlReplacesRanges(t *testing.T) {
+	backend := &CgroupBackend{
+		fakeIPIPv4: netip.MustParsePrefix("100.64.0.0/10"),
+	}
+	control := cgroupControl{
+		Flags:            cgroupFlagTCP | cgroupFlagHijackDNS | cgroupFlagFakeIPIPv6,
+		ListenerPort:     4242,
+		FakeIPIPv6Prefix: [16]byte{0: 0xfd},
+		FakeIPIPv6Mask:   [16]byte{0: 0xff},
+	}
+	backend.applyFakeIPControlLocked(&control)
+
+	if control.Flags&(cgroupFlagTCP|cgroupFlagHijackDNS) != cgroupFlagTCP|cgroupFlagHijackDNS {
+		t.Fatalf("unrelated flags were dropped: %#x", control.Flags)
+	}
+	if control.Flags&cgroupFlagFakeIPIPv4 == 0 {
+		t.Fatalf("expected the IPv4 fake-ip flag to be set: %#x", control.Flags)
+	}
+	if control.Flags&cgroupFlagFakeIPIPv6 != 0 {
+		t.Fatalf("expected the stale IPv6 fake-ip flag to be cleared: %#x", control.Flags)
+	}
+	if control.FakeIPIPv4Prefix != [4]byte{100, 64, 0, 0} {
+		t.Fatalf("unexpected IPv4 prefix: %v", control.FakeIPIPv4Prefix)
+	}
+	if control.FakeIPIPv4Mask != [4]byte{0xff, 0xc0, 0, 0} {
+		t.Fatalf("unexpected IPv4 mask: %v", control.FakeIPIPv4Mask)
+	}
+	if control.FakeIPIPv6Prefix != [16]byte{} || control.FakeIPIPv6Mask != [16]byte{} {
+		t.Fatal("expected the stale IPv6 range to be zeroed")
+	}
+	if control.ListenerPort != 4242 {
+		t.Fatalf("expected the listener port to survive, got %d", control.ListenerPort)
+	}
+}
+
+func TestApplyFakeIPControlClearsBothFamilies(t *testing.T) {
+	backend := &CgroupBackend{}
+	control := cgroupControl{
+		Flags:            cgroupFlagUDP | cgroupFlagFakeIPIPv4 | cgroupFlagFakeIPIPv6,
+		FakeIPIPv4Prefix: [4]byte{100, 64, 0, 0},
+	}
+	backend.applyFakeIPControlLocked(&control)
+	if control.Flags != cgroupFlagUDP {
+		t.Fatalf("expected only the unrelated flag to remain: %#x", control.Flags)
+	}
+	if control.FakeIPIPv4Prefix != [4]byte{} {
+		t.Fatalf("expected the range to be zeroed, got %v", control.FakeIPIPv4Prefix)
+	}
+}
+
+func TestSetFakeIPRangesRejectsWrongFamily(t *testing.T) {
+	backend := &CgroupBackend{}
+	if _, err := backend.SetFakeIPRanges(netip.MustParsePrefix("fc00::/7"), netip.Prefix{}); err == nil {
+		t.Fatal("expected an IPv6 prefix in the IPv4 slot to be rejected")
+	}
+	if _, err := backend.SetFakeIPRanges(netip.Prefix{}, netip.MustParsePrefix("10.0.0.0/8")); err == nil {
+		t.Fatal("expected an IPv4 prefix in the IPv6 slot to be rejected")
+	}
+	// A rejected range must not have been stored.
+	if ipv4, ipv6 := backend.FakeIPRanges(); ipv4.IsValid() || ipv6.IsValid() {
+		t.Fatalf("expected no range to be stored, got %s and %s", ipv4, ipv6)
+	}
+}
+
+func TestSetFakeIPRangesNilBackend(t *testing.T) {
+	var backend *CgroupBackend
+	if _, err := backend.SetFakeIPRanges(netip.Prefix{}, netip.Prefix{}); err == nil {
+		t.Fatal("expected a closed backend to be reported")
+	}
+	if ipv4, ipv6 := backend.FakeIPRanges(); ipv4.IsValid() || ipv6.IsValid() {
+		t.Fatal("expected zero ranges from a nil backend")
+	}
+}

--- a/common/ebpf/cgroup_policy_runtime.go
+++ b/common/ebpf/cgroup_policy_runtime.go
@@ -152,7 +152,16 @@ func (b *CgroupBackend) UpdateHostAddresses(addresses []netip.Addr) error {
 	}
 	b.hostIPv4 = slices.Clone(ipv4)
 	b.hostIPv6 = slices.Clone(ipv6)
-	return nil
+	// The packet program skips the host lookup entirely unless the control
+	// flags say the map is populated, so a set that only becomes non-empty
+	// after load -- an interface that appeared later, say -- has to move the
+	// flags with it or the new entries are never consulted.
+	return b.mutateCgroupControlLocked(b.applyHostAddressControlLocked)
+}
+
+func (b *CgroupBackend) applyHostAddressControlLocked(control *cgroupControl) {
+	control.Flags &^= cgroupFlagHostIPv4 | cgroupFlagHostIPv6
+	control.Flags |= b.hostAddressFlags()
 }
 
 type dualStackCIDRPrefixes struct {

--- a/common/ebpf/private_address.go
+++ b/common/ebpf/private_address.go
@@ -1,0 +1,31 @@
+package ebpf
+
+import (
+	"net/netip"
+	"slices"
+)
+
+// privateAddressPrefixes mirrors sb_ebpf_ipv4_private_address and
+// sb_ebpf_ipv6_private_address in native/private_address.h. The two must be
+// changed together: a consumer that plans routing around the bypass decision
+// would silently diverge from the packet program otherwise.
+//
+// The unspecified, loopback and multicast ranges the programs also bypass are
+// deliberately absent. Those are unconditional safety exceptions rather than
+// policy, they cannot be turned off with bypass_private_address, and no
+// consumer of this list has to reason about routing them.
+var privateAddressPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+}
+
+// PrivateAddressPrefixes returns the destination ranges the eBPF packet
+// programs bypass while bypass_private_address is enabled.
+func PrivateAddressPrefixes() []netip.Prefix {
+	return slices.Clone(privateAddressPrefixes)
+}

--- a/common/ebpf/private_address_test.go
+++ b/common/ebpf/private_address_test.go
@@ -1,0 +1,41 @@
+package ebpf
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// The list is the Go mirror of sb_ebpf_ipv4_private_address and
+// sb_ebpf_ipv6_private_address in native/private_address.h. Spelling the
+// expectation out here means an edit to one side without the other fails a
+// test instead of silently diverging from the packet program: consumers plan
+// routing around this list, so a mismatch would route traffic the program does
+// not actually bypass.
+func TestPrivateAddressPrefixes(t *testing.T) {
+	expected := []string{
+		"10.0.0.0/8",
+		"100.64.0.0/10",
+		"169.254.0.0/16",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"fc00::/7",
+		"fe80::/10",
+	}
+	prefixes := PrivateAddressPrefixes()
+	if len(prefixes) != len(expected) {
+		t.Fatalf("expected %d prefixes, got %d: %v", len(expected), len(prefixes), prefixes)
+	}
+	for index, text := range expected {
+		if prefixes[index] != netip.MustParsePrefix(text) {
+			t.Fatalf("prefix %d: expected %s, got %s", index, text, prefixes[index])
+		}
+	}
+}
+
+func TestPrivateAddressPrefixesIsCopy(t *testing.T) {
+	first := PrivateAddressPrefixes()
+	first[0] = netip.MustParsePrefix("203.0.113.0/24")
+	if second := PrivateAddressPrefixes(); second[0] != netip.MustParsePrefix("10.0.0.0/8") {
+		t.Fatalf("caller mutated the shared list: got %s", second[0])
+	}
+}

--- a/common/ebpf/shared_network_fakeip.go
+++ b/common/ebpf/shared_network_fakeip.go
@@ -1,0 +1,54 @@
+//go:build with_ebpf && (linux || android)
+
+package ebpf
+
+import (
+	"net/netip"
+)
+
+// SetFakeIPRanges replaces the fake-ip ranges the shared TC programs use to
+// force interception, and reports whether anything changed. The shared control
+// record is kept in memory, so unlike the cgroup path this rewrites the whole
+// record rather than reading it back.
+func (b *SharedNetworkBackend) SetFakeIPRanges(ipv4 netip.Prefix, ipv6 netip.Prefix) (bool, error) {
+	if b == nil {
+		return false, errBackendClosed
+	}
+	normalizedIPv4, err := normalizeAddressPrefix("IPv4 FakeIP range", ipv4, true)
+	if err != nil {
+		return false, err
+	}
+	normalizedIPv6, err := normalizeAddressPrefix("IPv6 FakeIP range", ipv6, false)
+	if err != nil {
+		return false, err
+	}
+	b.access.Lock()
+	defer b.access.Unlock()
+	if err = b.requireUsableLocked(); err != nil {
+		return false, err
+	}
+	previous := b.control
+	b.control.Flags &^= sharedNetworkFlagFakeIPIPv4 | sharedNetworkFlagFakeIPIPv6
+	b.control.FakeIPIPv4Prefix = [4]byte{}
+	b.control.FakeIPIPv4Mask = [4]byte{}
+	b.control.FakeIPIPv6Prefix = [16]byte{}
+	b.control.FakeIPIPv6Mask = [16]byte{}
+	if normalizedIPv4.IsValid() {
+		b.control.Flags |= sharedNetworkFlagFakeIPIPv4
+		b.control.FakeIPIPv4Prefix = normalizedIPv4.Addr().As4()
+		b.control.FakeIPIPv4Mask = prefixMask4(normalizedIPv4.Bits())
+	}
+	if normalizedIPv6.IsValid() {
+		b.control.Flags |= sharedNetworkFlagFakeIPIPv6
+		b.control.FakeIPIPv6Prefix = normalizedIPv6.Addr().As16()
+		b.control.FakeIPIPv6Mask = prefixMask16(normalizedIPv6.Bits())
+	}
+	if b.control == previous {
+		return false, nil
+	}
+	if err = b.updateControl(); err != nil {
+		b.control = previous
+		return false, err
+	}
+	return true, nil
+}

--- a/component/resolver/ebpf_bypass.go
+++ b/component/resolver/ebpf_bypass.go
@@ -1,6 +1,9 @@
 package resolver
 
 import (
+	"fmt"
+	"net/netip"
+	"strings"
 	"sync/atomic"
 
 	"go4.org/netipx"
@@ -13,3 +16,143 @@ import (
 // engage (matching sing-box's effective behavior). It is nil when no eBPF
 // inbound with a bypass policy is active.
 var EBFPBypassIPSet atomic.Pointer[netipx.IPSet]
+
+// EBPFBypassPolicy is the effective destination policy of a running eBPF
+// inbound: the private ranges when bypass_private_address is on, plus the
+// resolved bypass_rule_set CIDRs.
+//
+// It is wider than EBFPBypassIPSet, which the DNS fake-ip middleware consults
+// and which is only published for bypass_rule_set. This is the whole policy, so
+// other components can tell what the kernel is letting through.
+type EBPFBypassPolicy struct {
+	// Prefixes is the policy as configured, for reporting.
+	Prefixes []netip.Prefix
+	// Set is the same policy as a membership test. Per-connection lookups go
+	// through this, never through Prefixes: a bypass_rule_set holds thousands
+	// of entries and a linear scan would land on the connection path.
+	Set *netipx.IPSet
+	// TunDirect honours the bypass for a destination a TUN listener claimed,
+	// instead of handing the flow to the rule engine.
+	TunDirect bool
+}
+
+// EBPFBypassPolicyValue is published by the eBPF inbound while it is running,
+// and cleared when it stops.
+var EBPFBypassPolicyValue atomic.Pointer[EBPFBypassPolicy]
+
+// EBPFRouteExcludePrefixes is the subset of the bypass policy that a TUN
+// listener must keep out of its routes for the bypass to mean anything.
+//
+// It is deliberately narrower than the policy: only the fixed private ranges
+// are published here. A bypass_rule_set is resolved from rule providers that
+// have not finished loading when the TUN device is created, and sing-tun bakes
+// its route set at that moment, so a rule set could neither be applied in time
+// nor bounded in size -- excluding a country-sized IP set would install tens of
+// thousands of routes. Those destinations are handled by TunDirect instead.
+var EBPFRouteExcludePrefixes atomic.Pointer[[]netip.Prefix]
+
+// EBPFBypassedDirect reports whether a destination that only reached mihomo
+// because a TUN listener claimed its route should be connected directly.
+//
+// The eBPF inbound already decided to let this destination past the redirect;
+// the flow is here anyway because auto-route pointed the routing table at the
+// TUN device. Matching it against the rules is what turns the bypass into a
+// black hole: the rules were written expecting these destinations never to
+// arrive, so they fall through to whatever the final rule says, and a LAN or
+// geo-restricted address handed to a remote proxy simply times out.
+func EBPFBypassedDirect(destination netip.Addr) bool {
+	policy := EBPFBypassPolicyValue.Load()
+	if policy == nil || !policy.TunDirect || policy.Set == nil {
+		return false
+	}
+	if !destination.IsValid() {
+		return false
+	}
+	return policy.Set.Contains(destination.Unmap())
+}
+
+// TunRouteClaim is the destination range a running TUN listener has taken over
+// through auto-route, after its own route-exclude options were applied.
+//
+// It exists because an eBPF bypass and a TUN route exclusion are decisions at
+// two different layers: bypassing a destination in eBPF only means the socket
+// keeps its original destination, so the packet still follows the routing
+// table, and auto-route points that table at the TUN device. A destination
+// bypassed by eBPF but claimed here is therefore not direct at all -- it is
+// handled by TUN and routed by the rule engine.
+type TunRouteClaim struct {
+	// Claimed is the set of destinations routed into the TUN device. A nil set
+	// claims nothing.
+	Claimed *netipx.IPSet
+}
+
+// TunRouteClaimed is published by the TUN listener while it is running with
+// auto-route, and cleared when it stops. Nil means no TUN listener is claiming
+// destinations, so an eBPF bypass reaches the normal routing table.
+var TunRouteClaimed atomic.Pointer[TunRouteClaim]
+
+// TunClaimedPrefixes returns the subset of prefixes that a running TUN
+// listener has taken over, so the caller can report exactly which bypassed
+// destinations will not be direct. It returns nil when no TUN listener is
+// claiming anything.
+func TunClaimedPrefixes(prefixes []netip.Prefix) []netip.Prefix {
+	if len(prefixes) == 0 {
+		return nil
+	}
+	claim := TunRouteClaimed.Load()
+	if claim == nil || claim.Claimed == nil {
+		return nil
+	}
+	var builder netipx.IPSetBuilder
+	for _, prefix := range prefixes {
+		builder.AddPrefix(prefix)
+	}
+	builder.Intersect(claim.Claimed)
+	overlap, err := builder.IPSet()
+	if err != nil || overlap == nil {
+		return nil
+	}
+	return overlap.Prefixes()
+}
+
+// TunClaimedBypassPrefixes returns the eBPF-bypassed destinations that a
+// running TUN listener has taken over. An empty result means the two are not
+// fighting over anything: either no TUN listener is claiming routes, no eBPF
+// inbound is bypassing anything, or every bypassed destination was excluded
+// from the TUN routes.
+func TunClaimedBypassPrefixes() []netip.Prefix {
+	policy := EBPFBypassPolicyValue.Load()
+	if policy == nil {
+		return nil
+	}
+	return TunClaimedPrefixes(policy.Prefixes)
+}
+
+// tunBypassOverlapPrefixes bounds how many prefixes a single overlap report
+// spells out. A bypass_rule_set can hold thousands.
+const tunBypassOverlapPrefixes = 4
+
+// TunBypassOverlapMessage describes an overlap between the eBPF bypass policy
+// and the destinations a TUN listener routes into its device. It lives here so
+// both listeners report the condition identically -- either one can be the
+// second to start, and only that one knows the overlap exists.
+func TunBypassOverlapMessage(claimed []netip.Prefix, tunDirect bool) string {
+	shown := claimed
+	suffix := ""
+	if len(shown) > tunBypassOverlapPrefixes {
+		shown = shown[:tunBypassOverlapPrefixes]
+		suffix = fmt.Sprintf(" and %d more", len(claimed)-tunBypassOverlapPrefixes)
+	}
+	texts := make([]string, 0, len(shown))
+	for _, prefix := range shown {
+		texts = append(texts, prefix.String())
+	}
+	remedy := "Add them to tun.route-exclude-address, or give the rules a matching direct rule."
+	if tunDirect {
+		remedy = "They are connected directly on arrival instead of being matched against the rules; " +
+			"add them to tun.route-exclude-address to keep them off the TUN device entirely."
+	}
+	return fmt.Sprintf(
+		"TUN auto-route claims %d destination prefix(es) the eBPF inbound bypasses (%s%s). %s",
+		len(claimed), strings.Join(texts, ", "), suffix, remedy)
+}

--- a/component/resolver/ebpf_bypass.go
+++ b/component/resolver/ebpf_bypass.go
@@ -4,10 +4,167 @@ import (
 	"fmt"
 	"net/netip"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"go4.org/netipx"
 )
+
+// More than one eBPF inbound can run at once: the listener parser only rejects
+// duplicate names, and a local-mode and a shared-mode inbound -- or two on
+// different cgroup paths -- both attach successfully. So the coexistence state
+// below is a union of what every running inbound published, keyed by publisher.
+//
+// A single global would let the last inbound to start overwrite the others, and
+// would let the first one to close take their policy down with it. That second
+// case is not hypothetical: an inbound whose start fails closes itself, and
+// PatchInboundListeners closes dropped listeners after starting the new ones.
+//
+// A union is also the right answer on the merits. A flow that reached the TUN
+// device is one no eBPF inbound redirected, so it belongs to none of them; the
+// question is only whether some running inbound meant that destination to skip
+// the proxy.
+type ebpfBypassEntry struct {
+	dnsBypass    *netipx.IPSet
+	prefixes     []netip.Prefix
+	routeExclude []netip.Prefix
+	tunDirect    bool
+}
+
+var (
+	ebpfBypassAccess  sync.Mutex
+	ebpfBypassEntries map[uint64]*ebpfBypassEntry
+	ebpfBypassNextID  atomic.Uint64
+)
+
+// EBPFBypassPublisher is one inbound's slot in the registry, so a publisher
+// only ever replaces or removes its own contribution.
+//
+// The identity is an explicit id rather than the pointer: an empty struct is
+// zero-sized, and Go lets two distinct zero-sized allocations share an address,
+// which would silently merge two inbounds into one slot.
+type EBPFBypassPublisher struct {
+	id uint64
+}
+
+// NewEBPFBypassPublisher creates a slot. It contributes nothing until the first
+// Publish, so an inbound that fails to start and closes immediately leaves the
+// other inbounds untouched.
+func NewEBPFBypassPublisher() *EBPFBypassPublisher {
+	return &EBPFBypassPublisher{id: ebpfBypassNextID.Add(1)}
+}
+
+// Publish replaces this inbound's contribution to the union.
+//
+// dnsBypass is the set the DNS fake-ip middleware consults, and is nil unless
+// the inbound uses bypass_rule_set. prefixes is its effective bypass policy,
+// routeExclude the part of it a TUN listener should keep off its routes, and
+// tunDirect whether its bypassed destinations should be connected directly when
+// TUN claims them anyway.
+func (p *EBPFBypassPublisher) Publish(
+	dnsBypass *netipx.IPSet,
+	prefixes []netip.Prefix,
+	routeExclude []netip.Prefix,
+	tunDirect bool,
+) {
+	if p == nil || p.id == 0 {
+		return
+	}
+	ebpfBypassAccess.Lock()
+	defer ebpfBypassAccess.Unlock()
+	if ebpfBypassEntries == nil {
+		ebpfBypassEntries = make(map[uint64]*ebpfBypassEntry)
+	}
+	ebpfBypassEntries[p.id] = &ebpfBypassEntry{
+		dnsBypass:    dnsBypass,
+		prefixes:     prefixes,
+		routeExclude: routeExclude,
+		tunDirect:    tunDirect,
+	}
+	recomputeEBPFBypassLocked()
+}
+
+// Close removes this inbound's contribution. It is idempotent, so it is safe on
+// the failed-start path where the inbound never published anything.
+func (p *EBPFBypassPublisher) Close() {
+	if p == nil || p.id == 0 {
+		return
+	}
+	ebpfBypassAccess.Lock()
+	defer ebpfBypassAccess.Unlock()
+	if _, published := ebpfBypassEntries[p.id]; !published {
+		return
+	}
+	delete(ebpfBypassEntries, p.id)
+	recomputeEBPFBypassLocked()
+}
+
+// recomputeEBPFBypassLocked rebuilds the derived values every reader sees. The
+// entries are walked in map order, so each union goes through an IPSet: that
+// normalises and sorts the result, which keeps the published prefix list -- and
+// therefore the overlap reports built from it -- stable across recomputes.
+func recomputeEBPFBypassLocked() {
+	var (
+		dnsBuilder     netipx.IPSetBuilder
+		policyBuilder  netipx.IPSetBuilder
+		directBuilder  netipx.IPSetBuilder
+		excludeBuilder netipx.IPSetBuilder
+		anyDNS         bool
+		anyPolicy      bool
+		anyExclude     bool
+		tunDirect      bool
+	)
+	for _, entry := range ebpfBypassEntries {
+		if entry.dnsBypass != nil {
+			dnsBuilder.AddSet(entry.dnsBypass)
+			anyDNS = true
+		}
+		for _, prefix := range entry.prefixes {
+			policyBuilder.AddPrefix(prefix)
+			anyPolicy = true
+			if entry.tunDirect {
+				directBuilder.AddPrefix(prefix)
+			}
+		}
+		for _, prefix := range entry.routeExclude {
+			excludeBuilder.AddPrefix(prefix)
+			anyExclude = true
+		}
+		tunDirect = tunDirect || entry.tunDirect
+	}
+
+	EBFPBypassIPSet.Store(buildOptionalSet(&dnsBuilder, anyDNS))
+
+	if !anyPolicy {
+		EBPFBypassPolicyValue.Store(nil)
+	} else if policy := buildOptionalSet(&policyBuilder, true); policy == nil {
+		EBPFBypassPolicyValue.Store(nil)
+	} else {
+		EBPFBypassPolicyValue.Store(&EBPFBypassPolicy{
+			Prefixes:  policy.Prefixes(),
+			DirectSet: buildOptionalSet(&directBuilder, tunDirect),
+			TunDirect: tunDirect,
+		})
+	}
+
+	if excluded := buildOptionalSet(&excludeBuilder, anyExclude); excluded == nil {
+		EBPFRouteExcludePrefixes.Store(nil)
+	} else {
+		prefixes := excluded.Prefixes()
+		EBPFRouteExcludePrefixes.Store(&prefixes)
+	}
+}
+
+func buildOptionalSet(builder *netipx.IPSetBuilder, present bool) *netipx.IPSet {
+	if !present {
+		return nil
+	}
+	set, err := builder.IPSet()
+	if err != nil {
+		return nil
+	}
+	return set
+}
 
 // EBFPBypassIPSet holds the current eBPF inbound bypass CIDR set. It is
 // registered by the eBPF inbound and consulted by the DNS fake-ip middleware
@@ -17,27 +174,29 @@ import (
 // inbound with a bypass policy is active.
 var EBFPBypassIPSet atomic.Pointer[netipx.IPSet]
 
-// EBPFBypassPolicy is the effective destination policy of a running eBPF
-// inbound: the private ranges when bypass_private_address is on, plus the
+// EBPFBypassPolicy is the effective destination policy of the running eBPF
+// inbounds: the private ranges when bypass_private_address is on, plus the
 // resolved bypass_rule_set CIDRs.
 //
 // It is wider than EBFPBypassIPSet, which the DNS fake-ip middleware consults
 // and which is only published for bypass_rule_set. This is the whole policy, so
 // other components can tell what the kernel is letting through.
 type EBPFBypassPolicy struct {
-	// Prefixes is the policy as configured, for reporting.
+	// Prefixes is the union of every bypassed prefix, for reporting.
 	Prefixes []netip.Prefix
-	// Set is the same policy as a membership test. Per-connection lookups go
-	// through this, never through Prefixes: a bypass_rule_set holds thousands
-	// of entries and a linear scan would land on the connection path.
-	Set *netipx.IPSet
-	// TunDirect honours the bypass for a destination a TUN listener claimed,
-	// instead of handing the flow to the rule engine.
+	// DirectSet is the part of that union whose inbound asked for bypassed
+	// destinations to be connected directly when TUN claims them, as a
+	// membership test. Per-connection lookups go through this, never through
+	// Prefixes: a bypass_rule_set holds thousands of entries and a linear scan
+	// would land on the connection path. It is nil when no inbound asked.
+	DirectSet *netipx.IPSet
+	// TunDirect reports whether any inbound asked, which is what decides how
+	// an overlap is worded rather than how a flow is handled.
 	TunDirect bool
 }
 
-// EBPFBypassPolicyValue is published by the eBPF inbound while it is running,
-// and cleared when it stops.
+// EBPFBypassPolicyValue is derived from the running inbounds' contributions and
+// cleared when the last one goes away.
 var EBPFBypassPolicyValue atomic.Pointer[EBPFBypassPolicy]
 
 // EBPFRouteExcludePrefixes is the subset of the bypass policy that a TUN
@@ -62,13 +221,13 @@ var EBPFRouteExcludePrefixes atomic.Pointer[[]netip.Prefix]
 // geo-restricted address handed to a remote proxy simply times out.
 func EBPFBypassedDirect(destination netip.Addr) bool {
 	policy := EBPFBypassPolicyValue.Load()
-	if policy == nil || !policy.TunDirect || policy.Set == nil {
+	if policy == nil || policy.DirectSet == nil {
 		return false
 	}
 	if !destination.IsValid() {
 		return false
 	}
-	return policy.Set.Contains(destination.Unmap())
+	return policy.DirectSet.Contains(destination.Unmap())
 }
 
 // TunRouteClaim is the destination range a running TUN listener has taken over

--- a/component/resolver/ebpf_bypass_test.go
+++ b/component/resolver/ebpf_bypass_test.go
@@ -38,32 +38,26 @@ func prefixTexts(prefixes []netip.Prefix) []string {
 	return texts
 }
 
-func restoreClaimState(t *testing.T) {
+// publisher returns a registry slot that removes itself when the test ends, so
+// one test's policy never leaks into the next.
+func publisher(t *testing.T) *EBPFBypassPublisher {
 	t.Helper()
-	claim := TunRouteClaimed.Load()
-	policy := EBPFBypassPolicyValue.Load()
-	t.Cleanup(func() {
-		TunRouteClaimed.Store(claim)
-		EBPFBypassPolicyValue.Store(policy)
-	})
+	p := NewEBPFBypassPublisher()
+	t.Cleanup(p.Close)
+	return p
 }
 
-func storePolicy(t *testing.T, tunDirect bool, prefixes ...string) {
+func claimEverything(t *testing.T) {
 	t.Helper()
-	parsed := parsePrefixes(t, prefixes...)
-	var builder netipx.IPSetBuilder
-	for _, prefix := range parsed {
-		builder.AddPrefix(prefix)
-	}
-	set, err := builder.IPSet()
-	if err != nil {
-		t.Fatalf("build set: %s", err)
-	}
-	EBPFBypassPolicyValue.Store(&EBPFBypassPolicy{Prefixes: parsed, Set: set, TunDirect: tunDirect})
+	previous := TunRouteClaimed.Load()
+	TunRouteClaimed.Store(&TunRouteClaim{Claimed: prefixSet(t, "0.0.0.0/0")})
+	t.Cleanup(func() { TunRouteClaimed.Store(previous) })
 }
 
 func TestTunClaimedPrefixesNoClaim(t *testing.T) {
-	restoreClaimState(t)
+	previous := TunRouteClaimed.Load()
+	t.Cleanup(func() { TunRouteClaimed.Store(previous) })
+
 	TunRouteClaimed.Store(nil)
 	if claimed := TunClaimedPrefixes(parsePrefixes(t, "10.0.0.0/8")); claimed != nil {
 		t.Fatalf("expected no claim, got %v", claimed)
@@ -76,7 +70,9 @@ func TestTunClaimedPrefixesNoClaim(t *testing.T) {
 }
 
 func TestTunClaimedPrefixesIntersects(t *testing.T) {
-	restoreClaimState(t)
+	previous := TunRouteClaimed.Load()
+	t.Cleanup(func() { TunRouteClaimed.Store(previous) })
+
 	// auto-route claims everything except the LAN, which is what the eBPF
 	// route-exclude wiring is supposed to produce.
 	var builder netipx.IPSetBuilder
@@ -96,17 +92,144 @@ func TestTunClaimedPrefixesIntersects(t *testing.T) {
 }
 
 func TestTunClaimedBypassPrefixesUsesPublishedPolicy(t *testing.T) {
-	restoreClaimState(t)
-	TunRouteClaimed.Store(&TunRouteClaim{Claimed: prefixSet(t, "0.0.0.0/0")})
+	claimEverything(t)
 
-	EBPFBypassPolicyValue.Store(nil)
 	if claimed := TunClaimedBypassPrefixes(); claimed != nil {
 		t.Fatalf("expected nothing without a published policy, got %v", claimed)
 	}
 
-	storePolicy(t, true, "10.0.0.0/8")
+	publisher(t).Publish(nil, parsePrefixes(t, "10.0.0.0/8"), nil, true)
 	if texts := prefixTexts(TunClaimedBypassPrefixes()); len(texts) != 1 || texts[0] != "10.0.0.0/8" {
 		t.Fatalf("expected the bypassed prefix to be reported, got %v", texts)
+	}
+}
+
+// Several eBPF inbounds can run at once, so the published state is a union and
+// each publisher owns only its own contribution.
+func TestEBPFBypassPublisherUnion(t *testing.T) {
+	first := publisher(t)
+	second := publisher(t)
+
+	first.Publish(nil, parsePrefixes(t, "10.0.0.0/8"), parsePrefixes(t, "10.0.0.0/8"), true)
+	second.Publish(nil, parsePrefixes(t, "192.168.0.0/16"), parsePrefixes(t, "192.168.0.0/16"), true)
+
+	policy := EBPFBypassPolicyValue.Load()
+	if policy == nil || len(policy.Prefixes) != 2 {
+		t.Fatalf("expected both inbounds' prefixes, got %v", policy)
+	}
+	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) ||
+		!EBPFBypassedDirect(netip.MustParseAddr("192.168.1.1")) {
+		t.Fatal("expected both inbounds' destinations to be direct")
+	}
+	if excludes := EBPFRouteExcludePrefixes.Load(); excludes == nil || len(*excludes) != 2 {
+		t.Fatalf("expected both inbounds' route exclusions, got %v", excludes)
+	}
+
+	// Closing one must leave the other's policy standing. This is the case that
+	// broke before: an inbound that fails to start closes itself.
+	second.Close()
+	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected the surviving inbound's policy to stay published")
+	}
+	if EBPFBypassedDirect(netip.MustParseAddr("192.168.1.1")) {
+		t.Fatal("expected the closed inbound's policy to be dropped")
+	}
+	if excludes := EBPFRouteExcludePrefixes.Load(); excludes == nil || len(*excludes) != 1 {
+		t.Fatalf("expected only the surviving route exclusion, got %v", excludes)
+	}
+
+	first.Close()
+	if EBPFBypassPolicyValue.Load() != nil || EBPFRouteExcludePrefixes.Load() != nil {
+		t.Fatal("expected everything to be cleared once the last inbound closed")
+	}
+}
+
+// A publisher that never published anything -- an inbound whose start failed
+// before it got that far -- must not disturb the others when it closes.
+func TestEBPFBypassPublisherCloseWithoutPublish(t *testing.T) {
+	running := publisher(t)
+	running.Publish(nil, parsePrefixes(t, "10.0.0.0/8"), nil, true)
+
+	NewEBPFBypassPublisher().Close()
+	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected the running inbound's policy to survive")
+	}
+	// And closing twice stays harmless: Close is reached from an idempotent
+	// inbound Close.
+	running.Close()
+	running.Close()
+	if EBPFBypassPolicyValue.Load() != nil {
+		t.Fatal("expected the policy to be cleared")
+	}
+}
+
+// bypass_tun_direct is per inbound, so only the prefixes of the inbounds that
+// asked for it may be forced direct.
+func TestEBPFBypassPublisherTunDirectIsPerInbound(t *testing.T) {
+	direct := publisher(t)
+	split := publisher(t)
+	direct.Publish(nil, parsePrefixes(t, "10.0.0.0/8"), nil, true)
+	split.Publish(nil, parsePrefixes(t, "192.168.0.0/16"), nil, false)
+
+	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected the opted-in inbound's destination to be direct")
+	}
+	if EBPFBypassedDirect(netip.MustParseAddr("192.168.1.1")) {
+		t.Fatal("expected bypass_tun_direct: false to be honoured for its own prefixes")
+	}
+	// Both are still reported as bypassed, since both are claimed by TUN.
+	claimEverything(t)
+	if texts := prefixTexts(TunClaimedBypassPrefixes()); len(texts) != 2 {
+		t.Fatalf("expected both inbounds' prefixes to be reported, got %v", texts)
+	}
+}
+
+// The DNS fake-ip middleware reads a union too, and only bypass_rule_set feeds
+// it: publishing the private ranges there would make every A/AAAA query
+// resolve for real before fake-ip could answer it.
+func TestEBPFBypassPublisherDNSSet(t *testing.T) {
+	withRuleSet := publisher(t)
+	privateOnly := publisher(t)
+
+	privateOnly.Publish(nil, parsePrefixes(t, "10.0.0.0/8"), nil, true)
+	if EBFPBypassIPSet.Load() != nil {
+		t.Fatal("expected no DNS set from an inbound without bypass_rule_set")
+	}
+
+	withRuleSet.Publish(prefixSet(t, "203.0.113.0/24"), parsePrefixes(t, "203.0.113.0/24"), nil, true)
+	dnsSet := EBFPBypassIPSet.Load()
+	if dnsSet == nil || !dnsSet.Contains(netip.MustParseAddr("203.0.113.1")) {
+		t.Fatal("expected the rule-set addresses in the DNS set")
+	}
+	if dnsSet.Contains(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected the private ranges to stay out of the DNS set")
+	}
+
+	withRuleSet.Close()
+	if EBFPBypassIPSet.Load() != nil {
+		t.Fatal("expected the DNS set to be cleared with its inbound")
+	}
+}
+
+func TestEBPFBypassedDirect(t *testing.T) {
+	if EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected no direct decision without a policy")
+	}
+
+	p := publisher(t)
+	p.Publish(nil, parsePrefixes(t, "10.0.0.0/8"), nil, true)
+	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected a bypassed destination to be direct")
+	}
+	if EBPFBypassedDirect(netip.MustParseAddr("198.51.100.1")) {
+		t.Fatal("expected an unbypassed destination to keep matching rules")
+	}
+	// A v4-in-v6 destination is the same address as far as the policy goes.
+	if !EBPFBypassedDirect(netip.MustParseAddr("::ffff:10.1.2.3")) {
+		t.Fatal("expected a v4-mapped address to match the v4 policy")
+	}
+	if EBPFBypassedDirect(netip.Addr{}) {
+		t.Fatal("expected an invalid address to be ignored")
 	}
 }
 
@@ -135,37 +258,6 @@ func TestTunBypassOverlapMessageShortList(t *testing.T) {
 	}
 	if !strings.Contains(message, "10.0.0.0/8") {
 		t.Fatalf("expected the prefix to be listed, got %q", message)
-	}
-}
-
-func TestEBPFBypassedDirect(t *testing.T) {
-	restoreClaimState(t)
-
-	EBPFBypassPolicyValue.Store(nil)
-	if EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
-		t.Fatal("expected no direct decision without a policy")
-	}
-
-	// The mechanism has to stay switchable: a split setup can bypass a range in
-	// eBPF precisely so TUN handles it.
-	storePolicy(t, false, "10.0.0.0/8")
-	if EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
-		t.Fatal("expected bypass_tun_direct: false to be honoured")
-	}
-
-	storePolicy(t, true, "10.0.0.0/8")
-	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
-		t.Fatal("expected a bypassed destination to be direct")
-	}
-	if EBPFBypassedDirect(netip.MustParseAddr("198.51.100.1")) {
-		t.Fatal("expected an unbypassed destination to keep matching rules")
-	}
-	// A v4-in-v6 destination is the same address as far as the policy goes.
-	if !EBPFBypassedDirect(netip.MustParseAddr("::ffff:10.1.2.3")) {
-		t.Fatal("expected a v4-mapped address to match the v4 policy")
-	}
-	if EBPFBypassedDirect(netip.Addr{}) {
-		t.Fatal("expected an invalid address to be ignored")
 	}
 }
 

--- a/component/resolver/ebpf_bypass_test.go
+++ b/component/resolver/ebpf_bypass_test.go
@@ -1,0 +1,180 @@
+package resolver
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"go4.org/netipx"
+)
+
+func prefixSet(t *testing.T, prefixes ...string) *netipx.IPSet {
+	t.Helper()
+	var builder netipx.IPSetBuilder
+	for _, text := range prefixes {
+		builder.AddPrefix(netip.MustParsePrefix(text))
+	}
+	set, err := builder.IPSet()
+	if err != nil {
+		t.Fatalf("build set: %s", err)
+	}
+	return set
+}
+
+func parsePrefixes(t *testing.T, prefixes ...string) []netip.Prefix {
+	t.Helper()
+	parsed := make([]netip.Prefix, 0, len(prefixes))
+	for _, text := range prefixes {
+		parsed = append(parsed, netip.MustParsePrefix(text))
+	}
+	return parsed
+}
+
+func prefixTexts(prefixes []netip.Prefix) []string {
+	texts := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		texts = append(texts, prefix.String())
+	}
+	return texts
+}
+
+func restoreClaimState(t *testing.T) {
+	t.Helper()
+	claim := TunRouteClaimed.Load()
+	policy := EBPFBypassPolicyValue.Load()
+	t.Cleanup(func() {
+		TunRouteClaimed.Store(claim)
+		EBPFBypassPolicyValue.Store(policy)
+	})
+}
+
+func storePolicy(t *testing.T, tunDirect bool, prefixes ...string) {
+	t.Helper()
+	parsed := parsePrefixes(t, prefixes...)
+	var builder netipx.IPSetBuilder
+	for _, prefix := range parsed {
+		builder.AddPrefix(prefix)
+	}
+	set, err := builder.IPSet()
+	if err != nil {
+		t.Fatalf("build set: %s", err)
+	}
+	EBPFBypassPolicyValue.Store(&EBPFBypassPolicy{Prefixes: parsed, Set: set, TunDirect: tunDirect})
+}
+
+func TestTunClaimedPrefixesNoClaim(t *testing.T) {
+	restoreClaimState(t)
+	TunRouteClaimed.Store(nil)
+	if claimed := TunClaimedPrefixes(parsePrefixes(t, "10.0.0.0/8")); claimed != nil {
+		t.Fatalf("expected no claim, got %v", claimed)
+	}
+	// A published claim that claims nothing must read the same way.
+	TunRouteClaimed.Store(&TunRouteClaim{})
+	if claimed := TunClaimedPrefixes(parsePrefixes(t, "10.0.0.0/8")); claimed != nil {
+		t.Fatalf("expected no claim, got %v", claimed)
+	}
+}
+
+func TestTunClaimedPrefixesIntersects(t *testing.T) {
+	restoreClaimState(t)
+	// auto-route claims everything except the LAN, which is what the eBPF
+	// route-exclude wiring is supposed to produce.
+	var builder netipx.IPSetBuilder
+	builder.AddPrefix(netip.MustParsePrefix("0.0.0.0/0"))
+	builder.RemovePrefix(netip.MustParsePrefix("192.168.0.0/16"))
+	claimedSet, err := builder.IPSet()
+	if err != nil {
+		t.Fatalf("build set: %s", err)
+	}
+	TunRouteClaimed.Store(&TunRouteClaim{Claimed: claimedSet})
+
+	claimed := TunClaimedPrefixes(parsePrefixes(t, "192.168.0.0/16", "198.51.100.0/24"))
+	texts := prefixTexts(claimed)
+	if len(texts) != 1 || texts[0] != "198.51.100.0/24" {
+		t.Fatalf("expected only the still-routed prefix, got %v", texts)
+	}
+}
+
+func TestTunClaimedBypassPrefixesUsesPublishedPolicy(t *testing.T) {
+	restoreClaimState(t)
+	TunRouteClaimed.Store(&TunRouteClaim{Claimed: prefixSet(t, "0.0.0.0/0")})
+
+	EBPFBypassPolicyValue.Store(nil)
+	if claimed := TunClaimedBypassPrefixes(); claimed != nil {
+		t.Fatalf("expected nothing without a published policy, got %v", claimed)
+	}
+
+	storePolicy(t, true, "10.0.0.0/8")
+	if texts := prefixTexts(TunClaimedBypassPrefixes()); len(texts) != 1 || texts[0] != "10.0.0.0/8" {
+		t.Fatalf("expected the bypassed prefix to be reported, got %v", texts)
+	}
+}
+
+func TestTunBypassOverlapMessageTruncates(t *testing.T) {
+	claimed := parsePrefixes(t,
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10", "169.254.0.0/16", "fc00::/7")
+	message := TunBypassOverlapMessage(claimed, false)
+	if !strings.Contains(message, "claims 6 destination prefix(es)") {
+		t.Fatalf("expected the full count, got %q", message)
+	}
+	if !strings.Contains(message, "and 2 more") {
+		t.Fatalf("expected the remainder to be summarised, got %q", message)
+	}
+	if strings.Contains(message, "fc00::/7") {
+		t.Fatalf("expected the list to stop at the cap, got %q", message)
+	}
+	if !strings.Contains(message, "route-exclude-address") {
+		t.Fatalf("expected the remedy to be named, got %q", message)
+	}
+}
+
+func TestTunBypassOverlapMessageShortList(t *testing.T) {
+	message := TunBypassOverlapMessage(parsePrefixes(t, "10.0.0.0/8"), false)
+	if strings.Contains(message, "more") {
+		t.Fatalf("expected no remainder for a short list, got %q", message)
+	}
+	if !strings.Contains(message, "10.0.0.0/8") {
+		t.Fatalf("expected the prefix to be listed, got %q", message)
+	}
+}
+
+func TestEBPFBypassedDirect(t *testing.T) {
+	restoreClaimState(t)
+
+	EBPFBypassPolicyValue.Store(nil)
+	if EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected no direct decision without a policy")
+	}
+
+	// The mechanism has to stay switchable: a split setup can bypass a range in
+	// eBPF precisely so TUN handles it.
+	storePolicy(t, false, "10.0.0.0/8")
+	if EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected bypass_tun_direct: false to be honoured")
+	}
+
+	storePolicy(t, true, "10.0.0.0/8")
+	if !EBPFBypassedDirect(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected a bypassed destination to be direct")
+	}
+	if EBPFBypassedDirect(netip.MustParseAddr("198.51.100.1")) {
+		t.Fatal("expected an unbypassed destination to keep matching rules")
+	}
+	// A v4-in-v6 destination is the same address as far as the policy goes.
+	if !EBPFBypassedDirect(netip.MustParseAddr("::ffff:10.1.2.3")) {
+		t.Fatal("expected a v4-mapped address to match the v4 policy")
+	}
+	if EBPFBypassedDirect(netip.Addr{}) {
+		t.Fatal("expected an invalid address to be ignored")
+	}
+}
+
+func TestTunBypassOverlapMessageNamesTheHandler(t *testing.T) {
+	claimed := parsePrefixes(t, "10.0.0.0/8")
+	if handled := TunBypassOverlapMessage(claimed, true); !strings.Contains(handled, "connected directly on arrival") {
+		t.Fatalf("expected the handled case to say so, got %q", handled)
+	}
+	if unhandled := TunBypassOverlapMessage(claimed, false); strings.Contains(unhandled, "connected directly on arrival") {
+		t.Fatalf("expected the unhandled case to ask for a fix, got %q", unhandled)
+	}
+}

--- a/component/resolver/fakeip_range.go
+++ b/component/resolver/fakeip_range.go
@@ -1,0 +1,78 @@
+package resolver
+
+import (
+	"net/netip"
+	"sync"
+)
+
+// FakeIPRangeObserver is notified whenever the published ranges change. It is
+// invoked without the registry lock held, so an observer is free to read the
+// ranges back or to touch the registry again.
+type FakeIPRangeObserver = func(ipv4 netip.Prefix, ipv6 netip.Prefix)
+
+// The fake-ip ranges are published here for consumers that need the prefixes
+// themselves rather than a membership test on an address the pool has already
+// handed out. Enhancer only answers "is this a fake ip", which is of no use to
+// a component that has to compile the range into a policy before any traffic
+// exists: the eBPF inbound pushes the prefix and mask into a kernel map so its
+// packet program can force interception for fake-ip destinations even when the
+// configured range sits inside a range the same program would otherwise bypass
+// (100.64.0.0/10, say).
+var (
+	fakeIPRangeAccess    sync.Mutex
+	fakeIPRangeIPv4      netip.Prefix
+	fakeIPRangeIPv6      netip.Prefix
+	fakeIPRangeObservers map[int64]FakeIPRangeObserver
+	fakeIPRangeNextID    int64
+)
+
+// StoreFakeIPRanges publishes the active fake-ip ranges and notifies observers
+// when they changed. A family without an active pool must be published as a
+// zero prefix so consumers stop forcing interception for it.
+func StoreFakeIPRanges(ipv4 netip.Prefix, ipv6 netip.Prefix) {
+	fakeIPRangeAccess.Lock()
+	if ipv4 == fakeIPRangeIPv4 && ipv6 == fakeIPRangeIPv6 {
+		fakeIPRangeAccess.Unlock()
+		return
+	}
+	fakeIPRangeIPv4 = ipv4
+	fakeIPRangeIPv6 = ipv6
+	observers := make([]FakeIPRangeObserver, 0, len(fakeIPRangeObservers))
+	for _, observer := range fakeIPRangeObservers {
+		observers = append(observers, observer)
+	}
+	fakeIPRangeAccess.Unlock()
+	for _, observer := range observers {
+		observer(ipv4, ipv6)
+	}
+}
+
+// FakeIPRanges returns the active fake-ip ranges. Both are zero prefixes when
+// fake-ip is not in use.
+func FakeIPRanges() (netip.Prefix, netip.Prefix) {
+	fakeIPRangeAccess.Lock()
+	defer fakeIPRangeAccess.Unlock()
+	return fakeIPRangeIPv4, fakeIPRangeIPv6
+}
+
+// RegisterFakeIPRangeObserver installs an observer and returns the function
+// that removes it again. The observer is not called for the current value;
+// read it with FakeIPRanges after registering.
+func RegisterFakeIPRangeObserver(observer FakeIPRangeObserver) (remove func()) {
+	if observer == nil {
+		return func() {}
+	}
+	fakeIPRangeAccess.Lock()
+	if fakeIPRangeObservers == nil {
+		fakeIPRangeObservers = make(map[int64]FakeIPRangeObserver)
+	}
+	fakeIPRangeNextID++
+	id := fakeIPRangeNextID
+	fakeIPRangeObservers[id] = observer
+	fakeIPRangeAccess.Unlock()
+	return func() {
+		fakeIPRangeAccess.Lock()
+		delete(fakeIPRangeObservers, id)
+		fakeIPRangeAccess.Unlock()
+	}
+}

--- a/component/resolver/fakeip_range_test.go
+++ b/component/resolver/fakeip_range_test.go
@@ -1,0 +1,77 @@
+package resolver
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func restoreFakeIPRanges(t *testing.T) {
+	t.Helper()
+	ipv4, ipv6 := FakeIPRanges()
+	t.Cleanup(func() {
+		StoreFakeIPRanges(ipv4, ipv6)
+	})
+}
+
+func TestStoreFakeIPRangesNotifiesOnChange(t *testing.T) {
+	restoreFakeIPRanges(t)
+	StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
+
+	type observed struct {
+		ipv4 netip.Prefix
+		ipv6 netip.Prefix
+	}
+	var seen []observed
+	remove := RegisterFakeIPRangeObserver(func(ipv4 netip.Prefix, ipv6 netip.Prefix) {
+		seen = append(seen, observed{ipv4, ipv6})
+	})
+	defer remove()
+
+	ipv4 := netip.MustParsePrefix("100.64.0.0/10")
+	StoreFakeIPRanges(ipv4, netip.Prefix{})
+	if len(seen) != 1 || seen[0].ipv4 != ipv4 {
+		t.Fatalf("expected one notification carrying the new range, got %v", seen)
+	}
+	if gotIPv4, gotIPv6 := FakeIPRanges(); gotIPv4 != ipv4 || gotIPv6.IsValid() {
+		t.Fatalf("expected %s and no IPv6 range, got %s and %s", ipv4, gotIPv4, gotIPv6)
+	}
+
+	// An unchanged publication must not wake observers: updateDNS runs on every
+	// config apply, and each notification pushes a map write into the kernel.
+	StoreFakeIPRanges(ipv4, netip.Prefix{})
+	if len(seen) != 1 {
+		t.Fatalf("expected no notification for an unchanged value, got %v", seen)
+	}
+
+	StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
+	if len(seen) != 2 || seen[1].ipv4.IsValid() {
+		t.Fatalf("expected a notification clearing the range, got %v", seen)
+	}
+}
+
+func TestRegisterFakeIPRangeObserverRemove(t *testing.T) {
+	restoreFakeIPRanges(t)
+	StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
+
+	calls := 0
+	remove := RegisterFakeIPRangeObserver(func(netip.Prefix, netip.Prefix) {
+		calls++
+	})
+	remove()
+	// A second removal must stay harmless: the inbound calls its stop path from
+	// an idempotent Close.
+	remove()
+
+	StoreFakeIPRanges(netip.MustParsePrefix("198.18.0.0/16"), netip.Prefix{})
+	if calls != 0 {
+		t.Fatalf("expected no calls after removal, got %d", calls)
+	}
+}
+
+func TestRegisterFakeIPRangeObserverNil(t *testing.T) {
+	remove := RegisterFakeIPRangeObserver(nil)
+	if remove == nil {
+		t.Fatal("expected a usable remove function for a nil observer")
+	}
+	remove()
+}

--- a/docs/ebpf-inbound.md
+++ b/docs/ebpf-inbound.md
@@ -217,9 +217,46 @@ have:
 ## Relationship with TUN, TProxy, and Redir
 
 The eBPF inbound intercepts sockets inside the selected cgroup; it is not a
-full TUN device and does not route all host traffic by itself. It can coexist
-with TUN, TProxy, and Redir, but avoid attaching multiple transparent inbound
-mechanisms to the same cgroup or interface unless you intentionally split
-traffic with UID, CIDR, and `bypass-rule-set` policies. The shared-network mode
-uses TC on named downstream interfaces and can be used for hotspot forwarding
-while the cgroup path handles local apps.
+full TUN device and does not route all host traffic by itself. The shared-network
+mode uses TC on named downstream interfaces and can be used for hotspot
+forwarding while the cgroup path handles local apps.
+
+### Coexisting with TUN
+
+A bypass decision and a route exclusion live at different layers. Bypassing a
+destination here only means the socket keeps its original destination; the packet
+still follows the routing table, and TUN `auto-route` points that table at the
+TUN device. A bypassed destination TUN claims is therefore not direct: it enters
+the TUN stack and is routed by the rule engine, which black-holes it whenever no
+rule sends it direct and the matched proxy cannot reach the address.
+
+Two mechanisms keep the bypass meaningful, split by set size:
+
+| Bypass source | Mechanism | Where |
+|---------------|-----------|-------|
+| `bypass-private-address` | the fixed private prefixes are published for route exclusion, so `auto-route` never claims them | `listener/sing_tun` reads `resolver.EBPFRouteExcludePrefixes` while building `tun.Options` |
+| `bypass-rule-set` | the destination is connected directly on arrival instead of being matched against the rules (`bypass-tun-direct`, default true) | `tunnel.resolveMetadata` consults `resolver.EBPFBypassedDirect` for `C.TUN` flows |
+
+A rule set cannot use route exclusion: it resolves after the TUN device already
+baked its route set, and excluding a country-sized IP set would install tens of
+thousands of routes. The fake-ip ranges and the TUN device's own addresses are
+always kept on the routes.
+
+With `bypass-tun-direct: false` the overlap is only reported, not handled. Both
+listeners report it, because either one can be the second to start.
+
+Beyond that, avoid attaching multiple transparent inbound mechanisms to the same
+cgroup or interface unless you intentionally split traffic with UID, CIDR, and
+`bypass-rule-set` policies. In particular do not enable shared mode and TUN
+`auto-redirect` on the same interface: TC ingress rewrites the destination
+before netfilter sees the packet. `strict-route` is best left off, since it
+reorders the policy routing the redirect address depends on.
+
+### FakeIP
+
+The fake-ip ranges are pushed into the kernel policy so a fake destination is
+intercepted even when it would otherwise be bypassed -- the address only regains
+meaning once the tunnel maps it back to its domain. This matters when the
+configured range sits inside a bypassed range, as `fake-ip-range: 100.64.0.0/10`
+does. The ranges follow `dns.fake-ip-range`/`fake-ip-range6` at runtime, so a
+config reload that changes them reaches a running inbound.

--- a/docs/ebpf-inbound.md
+++ b/docs/ebpf-inbound.md
@@ -245,6 +245,13 @@ always kept on the routes.
 With `bypass-tun-direct: false` the overlap is only reported, not handled. Both
 listeners report it, because either one can be the second to start.
 
+Several eBPF inbounds can run at once -- the listener parser only rejects
+duplicate names -- so the published state is a union keyed by publishing
+inbound, and `bypass-tun-direct` stays per inbound: only the prefixes of the
+inbounds that asked for it are connected directly. Closing one inbound removes
+only its own contribution, which matters because an inbound whose start fails
+closes itself.
+
 Beyond that, avoid attaching multiple transparent inbound mechanisms to the same
 cgroup or interface unless you intentionally split traffic with UID, CIDR, and
 `bypass-rule-set` policies. In particular do not enable shared mode and TUN

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -240,7 +240,27 @@ func updateNTP(c *config.NTP) {
 	}
 }
 
+// storeFakeIPRanges publishes the ranges of the pools that are actually in use.
+// A family without a pool is published as a zero prefix so a consumer stops
+// treating that range as synthetic.
+func storeFakeIPRanges(c *config.DNS) {
+	var ipv4, ipv6 netip.Prefix
+	if c.Enable {
+		if c.FakeIPPool != nil {
+			ipv4 = c.FakeIPPool.IPNet()
+		}
+		if c.FakeIPPool6 != nil {
+			ipv6 = c.FakeIPPool6.IPNet()
+		}
+	}
+	resolver.StoreFakeIPRanges(ipv4, ipv6)
+}
+
 func updateDNS(c *config.DNS, generalIPv6 bool) {
+	// Publish the fake-ip ranges before anything can read them back: the eBPF
+	// inbound compiles them into a kernel policy when it starts, and listeners
+	// are (re)created right after this.
+	storeFakeIPRanges(c)
 	if !c.Enable {
 		resolver.DefaultResolver = nil
 		resolver.DefaultHostMapper = nil

--- a/listener/config/ebpf.go
+++ b/listener/config/ebpf.go
@@ -12,6 +12,7 @@ type EBPF struct {
 	DNSMode              string     `json:"dns-mode" yaml:"dns-mode"`
 	BypassPrivateAddress *bool      `json:"bypass-private-address" yaml:"bypass-private-address" inbound:"bypass-private-address,omitempty"`
 	BypassRuleSet        []string   `json:"bypass-rule-set" yaml:"bypass-rule-set"`
+	BypassTUNDirect      *bool      `json:"bypass-tun-direct" yaml:"bypass-tun-direct" inbound:"bypass-tun-direct,omitempty"`
 	Local                EBPFLocal  `json:"local" yaml:"local" inbound:"local,omitempty"`
 	Shared               EBPFShared `json:"shared" yaml:"shared" inbound:"shared,omitempty"`
 }

--- a/listener/inbound/ebpf.go
+++ b/listener/inbound/ebpf.go
@@ -17,6 +17,7 @@ type EBPFOption struct {
 	DNSMode              string        `inbound:"dns-mode,omitempty"`
 	BypassPrivateAddress *bool         `inbound:"bypass-private-address,omitempty"`
 	BypassRuleSet        []string      `inbound:"bypass-rule-set,omitempty"`
+	BypassTUNDirect      *bool         `inbound:"bypass-tun-direct,omitempty"`
 	Local                LC.EBPFLocal  `inbound:"local,omitempty"`
 	Shared               LC.EBPFShared `inbound:"shared,omitempty"`
 }
@@ -47,6 +48,7 @@ func NewEBPF(options *EBPFOption) (*EBPF, error) {
 			DNSMode:              options.DNSMode,
 			BypassPrivateAddress: options.BypassPrivateAddress,
 			BypassRuleSet:        options.BypassRuleSet,
+			BypassTUNDirect:      options.BypassTUNDirect,
 			Local:                options.Local,
 			Shared:               options.Shared,
 		},

--- a/listener/sing_ebpf/fakeip.go
+++ b/listener/sing_ebpf/fakeip.go
@@ -1,0 +1,70 @@
+//go:build with_ebpf && (linux || android)
+
+package sing_ebpf
+
+import (
+	"net/netip"
+
+	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/log"
+)
+
+// The fake-ip ranges have to reach the kernel policy, not just the tunnel: a
+// fake address carries no routable meaning, so it must be intercepted even when
+// the destination would otherwise be bypassed. mihomo maps it back to its
+// domain only once the flow reaches the tunnel, so a bypassed fake address is a
+// dead end.
+//
+// This matters whenever the configured range sits inside a range the program
+// bypasses. `fake-ip-range: 100.64.0.0/10` is inside the private set that
+// bypass_private_address covers by default, so without this the whole fake-ip
+// pool was handed straight past the redirect.
+func (i *Inbound) startFakeIPTracking() {
+	i.fakeIPRangeRemove = resolver.RegisterFakeIPRangeObserver(i.updateFakeIPRanges)
+	// Register first, then read: a change published between the two is applied
+	// twice rather than lost.
+	i.updateFakeIPRanges(resolver.FakeIPRanges())
+}
+
+func (i *Inbound) stopFakeIPTracking() {
+	if i.fakeIPRangeRemove == nil {
+		return
+	}
+	i.fakeIPRangeRemove()
+	i.fakeIPRangeRemove = nil
+}
+
+func (i *Inbound) updateFakeIPRanges(ipv4 netip.Prefix, ipv6 netip.Prefix) {
+	if backend := i.backendInstance(); backend != nil {
+		changed, err := backend.SetFakeIPRanges(ipv4, ipv6)
+		switch {
+		case err != nil:
+			log.Warnln("[EBPF] update local cgroup fake-ip ranges: %s", err.Error())
+		case changed:
+			log.Infoln("[EBPF] local cgroup fake-ip ranges: ipv4=%s, ipv6=%s",
+				fakeIPRangeText(ipv4), fakeIPRangeText(ipv6))
+		}
+	}
+	if i.sharedNetwork == nil {
+		return
+	}
+	shared := i.sharedNetwork.sharedBackendInstance()
+	if shared == nil || shared.IsClosed() {
+		return
+	}
+	changed, err := shared.SetFakeIPRanges(ipv4, ipv6)
+	switch {
+	case err != nil:
+		log.Warnln("[EBPF] update shared-network fake-ip ranges: %s", err.Error())
+	case changed:
+		log.Infoln("[EBPF] shared-network fake-ip ranges: ipv4=%s, ipv6=%s",
+			fakeIPRangeText(ipv4), fakeIPRangeText(ipv6))
+	}
+}
+
+func fakeIPRangeText(prefix netip.Prefix) string {
+	if !prefix.IsValid() {
+		return "off"
+	}
+	return prefix.String()
+}

--- a/listener/sing_ebpf/inbound.go
+++ b/listener/sing_ebpf/inbound.go
@@ -25,6 +25,8 @@ import (
 
 	E "github.com/metacubex/sing/common/exceptions"
 	"github.com/metacubex/sing/common/network"
+
+	"go4.org/netipx"
 )
 
 // minimumUDPTimeout bounds udp-timeout from below. The periodic sweeper derives
@@ -98,6 +100,8 @@ type Inbound struct {
 	localNetwork       *localNetworkMonitor
 	fakeIPRangeRemove  func()
 	tunOverlapWarnings warningLimiter
+	bypassPublisher    *resolver.EBPFBypassPublisher
+	dnsBypassSet       *netipx.IPSet
 
 	bypassRuleSetAccess   sync.Mutex
 	bypassRuleSet         []P.RuleProvider
@@ -229,6 +233,10 @@ func New(ctx context.Context, options LC.EBPF, tunnel C.Tunnel, additions ...inb
 		androidUIDOptions: newAndroidUIDOptions(options.Local),
 	}
 	inboundListener.tunOverlapWarnings.interval = tunOverlapWarningInterval
+	// Several eBPF inbounds can run at once, so each keeps its own slot in the
+	// coexistence registry: closing one -- including this one, if start fails
+	// below -- must not drop what the others published.
+	inboundListener.bypassPublisher = resolver.NewEBPFBypassPublisher()
 
 	rp, ok := tunnel.(P.Tunnel)
 	if !ok {
@@ -424,9 +432,7 @@ func (i *Inbound) Close() error {
 		i.stopFakeIPTracking()
 		i.stopLocalNetworkMonitor()
 		i.stopBypassRuleSets()
-		resolver.EBFPBypassIPSet.Store(nil)
-		resolver.EBPFBypassPolicyValue.Store(nil)
-		resolver.EBPFRouteExcludePrefixes.Store(nil)
+		i.bypassPublisher.Close()
 		if i.sharedNetwork != nil {
 			closeErr = i.sharedNetwork.Close()
 		}

--- a/listener/sing_ebpf/inbound.go
+++ b/listener/sing_ebpf/inbound.go
@@ -73,6 +73,7 @@ type Inbound struct {
 	androidUIDOptions        *androidUIDOptions
 	udpTimeout               time.Duration
 	bypassPrivateAddress     bool
+	bypassTUNDirect          bool
 	sharedNetworkMapCapacity ECommon.SharedNetworkMapCapacities
 	sharedNetworkIncludeMAC  []ECommon.MACAddress
 	sharedNetworkExcludeMAC  []ECommon.MACAddress
@@ -93,6 +94,10 @@ type Inbound struct {
 
 	tcpRedirectPressure *mapPressureWatcher
 	udpRedirectPressure *mapPressureWatcher
+
+	localNetwork       *localNetworkMonitor
+	fakeIPRangeRemove  func()
+	tunOverlapWarnings warningLimiter
 
 	bypassRuleSetAccess   sync.Mutex
 	bypassRuleSet         []P.RuleProvider
@@ -182,6 +187,10 @@ func New(ctx context.Context, options LC.EBPF, tunnel C.Tunnel, additions ...inb
 	}
 	udpTimeout := resolveUDPTimeout(options.UDPTimeout)
 	bypassPrivateAddress := options.BypassPrivateAddress == nil || *options.BypassPrivateAddress
+	// On by default: a destination this inbound bypasses is one the user asked
+	// to keep off the proxy, and letting TUN hand it to the rules instead is
+	// what makes a bypassed address unreachable.
+	bypassTUNDirect := options.BypassTUNDirect == nil || *options.BypassTUNDirect
 
 	inboundListener := &Inbound{
 		ctx:                      ctx,
@@ -202,6 +211,7 @@ func New(ctx context.Context, options LC.EBPF, tunnel C.Tunnel, additions ...inb
 		cgroupMapCapacity:        cgroupMapCapacity,
 		udpTimeout:               udpTimeout,
 		bypassPrivateAddress:     bypassPrivateAddress,
+		bypassTUNDirect:          bypassTUNDirect,
 		sharedNetworkMapCapacity: sharedNetworkMapCapacity,
 		sharedNetworkIncludeMAC:  sharedNetworkIncludeMAC,
 		sharedNetworkExcludeMAC:  sharedNetworkExcludeMAC,
@@ -218,6 +228,7 @@ func New(ctx context.Context, options LC.EBPF, tunnel C.Tunnel, additions ...inb
 		},
 		androidUIDOptions: newAndroidUIDOptions(options.Local),
 	}
+	inboundListener.tunOverlapWarnings.interval = tunOverlapWarningInterval
 
 	rp, ok := tunnel.(P.Tunnel)
 	if !ok {
@@ -273,6 +284,10 @@ func (i *Inbound) start() error {
 		}
 		policy := i.cgroupPolicy
 		policy.EnableBypassCIDR = true
+		// A fake-ip destination has to be intercepted even when it would
+		// otherwise be bypassed: the address only regains meaning once the
+		// tunnel maps it back to its domain.
+		fakeIPIPv4, fakeIPIPv6 := resolver.FakeIPRanges()
 		backend, err := ECommon.PrepareCgroup(ECommon.CgroupConfig{
 			Path:          i.cgroupPath,
 			EnableTCP:     i.enableTCP,
@@ -282,6 +297,8 @@ func (i *Inbound) start() error {
 			IPv6Available: i.cgroupIPv6Available,
 			RedirectIPv4:  i.redirectIPv4Prefix,
 			RedirectIPv6:  i.redirectIPv6Prefix,
+			FakeIPIPv4:    fakeIPIPv4,
+			FakeIPIPv6:    fakeIPIPv6,
 			MapCapacity:   i.cgroupMapCapacity,
 			UDPTimeout:    i.udpTimeout,
 			Policy:        policy,
@@ -363,6 +380,16 @@ func (i *Inbound) start() error {
 			}
 		}
 	}
+	if i.cgroupEnabled {
+		i.startLocalNetworkMonitor()
+	}
+	// Publish the bypass policy even when no bypass_rule_set refresh will ever
+	// run (shared-only mode, or no rule sets configured), so the TUN listener
+	// can still report an overlap with the private ranges.
+	i.bypassRuleSetAccess.Lock()
+	i.publishBypassPolicyLocked()
+	i.bypassRuleSetAccess.Unlock()
+	i.startFakeIPTracking()
 	reportKernelCapabilities(
 		i.kernelProbeMode(),
 		i.options.Network,
@@ -394,8 +421,12 @@ func (i *Inbound) Close() error {
 	var closeErr error
 	i.closeOnce.Do(func() {
 		i.stopUDPPeriodic()
+		i.stopFakeIPTracking()
+		i.stopLocalNetworkMonitor()
 		i.stopBypassRuleSets()
 		resolver.EBFPBypassIPSet.Store(nil)
+		resolver.EBPFBypassPolicyValue.Store(nil)
+		resolver.EBPFRouteExcludePrefixes.Store(nil)
 		if i.sharedNetwork != nil {
 			closeErr = i.sharedNetwork.Close()
 		}

--- a/listener/sing_ebpf/network_monitor.go
+++ b/listener/sing_ebpf/network_monitor.go
@@ -1,0 +1,60 @@
+//go:build with_ebpf && (linux || android)
+
+package sing_ebpf
+
+import (
+	"github.com/metacubex/mihomo/log"
+
+	list "github.com/metacubex/sing/common/x/list"
+
+	tun "github.com/metacubex/sing-tun"
+)
+
+// localNetworkMonitor keeps the local cgroup policy in step with the machine's
+// interfaces.
+//
+// The shared TC manager already has a monitor, but it owns and closes it, and
+// the two paths are enabled independently: local mode on its own still has to
+// learn about address changes, because its host-address policy is compiled from
+// the current interface addresses. Without this the policy stayed at whatever
+// the machine looked like when the inbound started -- and since listeners start
+// before the TUN device is created, that snapshot never contained the TUN
+// address at all.
+//
+// Monitoring is best effort. A kernel or vendor policy that refuses the netlink
+// subscription (Android 14+ restricts it) must not stop the inbound from
+// attaching; the policy then simply keeps its startup value, which is the
+// behaviour that existed before.
+type localNetworkMonitor struct {
+	monitor  tun.NetworkUpdateMonitor
+	callback *list.Element[tun.NetworkUpdateCallback]
+}
+
+func (i *Inbound) startLocalNetworkMonitor() {
+	monitor, err := tun.NewNetworkUpdateMonitor(log.SingLogger)
+	if err != nil {
+		log.Debugln("[EBPF] local interface monitor unavailable, host addresses keep their startup value: %s", err.Error())
+		return
+	}
+	if err = monitor.Start(); err != nil {
+		_ = monitor.Close()
+		log.Debugln("[EBPF] start local interface monitor, host addresses keep their startup value: %s", err.Error())
+		return
+	}
+	i.localNetwork = &localNetworkMonitor{
+		monitor:  monitor,
+		callback: monitor.RegisterCallback(i.InterfaceUpdated),
+	}
+}
+
+func (i *Inbound) stopLocalNetworkMonitor() {
+	local := i.localNetwork
+	if local == nil {
+		return
+	}
+	i.localNetwork = nil
+	if local.callback != nil {
+		local.monitor.UnregisterCallback(local.callback)
+	}
+	_ = local.monitor.Close()
+}

--- a/listener/sing_ebpf/policy.go
+++ b/listener/sing_ebpf/policy.go
@@ -172,5 +172,6 @@ func (i *Inbound) applyBypassCIDRLocked() (bool, error) {
 	} else {
 		resolver.EBFPBypassIPSet.Store(nil)
 	}
+	i.publishBypassPolicyLocked()
 	return updated, nil
 }

--- a/listener/sing_ebpf/policy.go
+++ b/listener/sing_ebpf/policy.go
@@ -6,7 +6,6 @@ import (
 	"net/netip"
 	"slices"
 
-	"github.com/metacubex/mihomo/component/resolver"
 	ECommon "github.com/metacubex/mihomo/common/ebpf"
 	P "github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
@@ -157,20 +156,20 @@ func (i *Inbound) applyBypassCIDRLocked() (bool, error) {
 			}
 		}
 	}
-	// Publish the effective bypass CIDR set to the DNS fake-ip middleware so
-	// domains whose real addresses fall inside it keep their real IP and the
-	// kernel eBPF bypass can engage. Only publish when bypass_rule_set is used.
+	// Recompute the set the DNS fake-ip middleware consults, so domains whose
+	// real addresses fall inside it keep their real IP and the kernel eBPF
+	// bypass can engage. Only bypass_rule_set feeds it; publishing the private
+	// ranges here would make every A/AAAA query resolve for real before
+	// fake-ip could answer it.
+	i.dnsBypassSet = nil
 	if len(i.bypassRuleSet) > 0 {
 		var builder netipx.IPSetBuilder
 		for _, prefix := range i.bypassCIDR {
 			builder.AddPrefix(prefix)
 		}
-		bypassSet, buildErr := builder.IPSet()
-		if buildErr == nil {
-			resolver.EBFPBypassIPSet.Store(bypassSet)
+		if bypassSet, buildErr := builder.IPSet(); buildErr == nil {
+			i.dnsBypassSet = bypassSet
 		}
-	} else {
-		resolver.EBFPBypassIPSet.Store(nil)
 	}
 	i.publishBypassPolicyLocked()
 	return updated, nil

--- a/listener/sing_ebpf/shared_network.go
+++ b/listener/sing_ebpf/shared_network.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	ECommon "github.com/metacubex/mihomo/common/ebpf"
+	"github.com/metacubex/mihomo/component/resolver"
 	LC "github.com/metacubex/mihomo/listener/config"
 	"github.com/metacubex/mihomo/log"
 
@@ -58,6 +59,9 @@ func (s *sharedNetwork) Start(cgroupBackend *ECommon.CgroupBackend) error {
 	if err := s.startListeners(); err != nil {
 		return E.Errors(err, s.closeListeners())
 	}
+	// Same reason as the cgroup path: a fake-ip destination carries no routable
+	// meaning, so it must be intercepted even when policy would bypass it.
+	fakeIPIPv4, fakeIPIPv6 := resolver.FakeIPRanges()
 	backend, err := ECommon.PrepareSharedNetwork(cgroupBackend, ECommon.SharedNetworkConfig{
 		ListenerPort:         s.listeners.selectedPort(),
 		EnableTCP:            s.inbound.enableTCP,
@@ -67,6 +71,8 @@ func (s *sharedNetwork) Start(cgroupBackend *ECommon.CgroupBackend) error {
 		BypassPrivateAddress: s.inbound.bypassPrivateAddress,
 		RedirectIPv4:         s.inbound.redirectIPv4Prefix,
 		RedirectIPv6:         s.inbound.sharedRedirectIPv6Prefix(),
+		FakeIPIPv4:           fakeIPIPv4,
+		FakeIPIPv6:           fakeIPIPv6,
 		IncludeSourceCIDR:    s.options.IncludeSourceCIDR,
 		ExcludeSourceCIDR:    s.options.ExcludeSourceCIDR,
 		IncludeSourceMAC:     s.inbound.sharedNetworkIncludeMAC,

--- a/listener/sing_ebpf/tun_coexist.go
+++ b/listener/sing_ebpf/tun_coexist.go
@@ -4,14 +4,11 @@ package sing_ebpf
 
 import (
 	"net/netip"
-	"slices"
 	"time"
 
 	ECommon "github.com/metacubex/mihomo/common/ebpf"
 	"github.com/metacubex/mihomo/component/resolver"
 	"github.com/metacubex/mihomo/log"
-
-	"go4.org/netipx"
 )
 
 // A claimed-prefix overlap is a configuration condition, not a packet event:
@@ -38,42 +35,12 @@ const tunOverlapWarningInterval = 10 * time.Minute
 //
 // The caller holds bypassRuleSetAccess.
 func (i *Inbound) publishBypassPolicyLocked() {
+	var routeExclude []netip.Prefix
 	if i.bypassPrivateAddress {
-		excludes := ECommon.PrivateAddressPrefixes()
-		resolver.EBPFRouteExcludePrefixes.Store(&excludes)
-	} else {
-		resolver.EBPFRouteExcludePrefixes.Store(nil)
+		routeExclude = ECommon.PrivateAddressPrefixes()
 	}
 	prefixes := i.effectiveBypassPrefixesLocked()
-	if len(prefixes) == 0 {
-		resolver.EBPFBypassPolicyValue.Store(nil)
-		return
-	}
-	// An interface change republishes an unchanged policy, and building the
-	// membership set means sorting every prefix of a rule set that can hold
-	// thousands. Only the overlap report below has to run every time.
-	published := resolver.EBPFBypassPolicyValue.Load()
-	if published == nil ||
-		published.TunDirect != i.bypassTUNDirect ||
-		!slices.Equal(published.Prefixes, prefixes) {
-		var builder netipx.IPSetBuilder
-		for _, prefix := range prefixes {
-			builder.AddPrefix(prefix)
-		}
-		set, err := builder.IPSet()
-		if err != nil {
-			// Without the set there is no membership test, and publishing the
-			// policy without one would quietly disable bypass_tun_direct.
-			log.Warnln("[EBPF] compile the bypass policy for TUN coexistence: %s", err.Error())
-			resolver.EBPFBypassPolicyValue.Store(nil)
-			return
-		}
-		resolver.EBPFBypassPolicyValue.Store(&resolver.EBPFBypassPolicy{
-			Prefixes:  prefixes,
-			Set:       set,
-			TunDirect: i.bypassTUNDirect,
-		})
-	}
+	i.bypassPublisher.Publish(i.dnsBypassSet, prefixes, routeExclude, i.bypassTUNDirect)
 	claimed := resolver.TunClaimedPrefixes(prefixes)
 	if len(claimed) == 0 {
 		return

--- a/listener/sing_ebpf/tun_coexist.go
+++ b/listener/sing_ebpf/tun_coexist.go
@@ -1,0 +1,103 @@
+//go:build with_ebpf && (linux || android)
+
+package sing_ebpf
+
+import (
+	"net/netip"
+	"slices"
+	"time"
+
+	ECommon "github.com/metacubex/mihomo/common/ebpf"
+	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/log"
+
+	"go4.org/netipx"
+)
+
+// A claimed-prefix overlap is a configuration condition, not a packet event:
+// it holds until someone edits the config, so the default ten-second limiter
+// would just repeat it forever.
+const tunOverlapWarningInterval = 10 * time.Minute
+
+// publishBypassPolicyLocked republishes the effective bypass policy and reports
+// any bypassed destination a running TUN listener has taken over.
+//
+// Bypassing a destination in eBPF only means the socket keeps its original
+// destination: the packet still follows the routing table, and TUN auto-route
+// points that table at the TUN device. A bypassed destination that TUN claims is
+// therefore not direct at all -- it is proxied by whatever the rule engine
+// picks, which is a black hole for a LAN or otherwise proxy-unreachable address
+// whenever the rules have no direct rule covering it.
+//
+// Two mechanisms answer that, and they split by size. The fixed private ranges
+// are published for route exclusion, so TUN never claims them in the first
+// place. A bypass_rule_set cannot go that way -- it resolves after the TUN
+// device already baked its route set, and excluding a country-sized IP set would
+// install tens of thousands of routes -- so those destinations are honoured on
+// arrival instead, by bypass_tun_direct.
+//
+// The caller holds bypassRuleSetAccess.
+func (i *Inbound) publishBypassPolicyLocked() {
+	if i.bypassPrivateAddress {
+		excludes := ECommon.PrivateAddressPrefixes()
+		resolver.EBPFRouteExcludePrefixes.Store(&excludes)
+	} else {
+		resolver.EBPFRouteExcludePrefixes.Store(nil)
+	}
+	prefixes := i.effectiveBypassPrefixesLocked()
+	if len(prefixes) == 0 {
+		resolver.EBPFBypassPolicyValue.Store(nil)
+		return
+	}
+	// An interface change republishes an unchanged policy, and building the
+	// membership set means sorting every prefix of a rule set that can hold
+	// thousands. Only the overlap report below has to run every time.
+	published := resolver.EBPFBypassPolicyValue.Load()
+	if published == nil ||
+		published.TunDirect != i.bypassTUNDirect ||
+		!slices.Equal(published.Prefixes, prefixes) {
+		var builder netipx.IPSetBuilder
+		for _, prefix := range prefixes {
+			builder.AddPrefix(prefix)
+		}
+		set, err := builder.IPSet()
+		if err != nil {
+			// Without the set there is no membership test, and publishing the
+			// policy without one would quietly disable bypass_tun_direct.
+			log.Warnln("[EBPF] compile the bypass policy for TUN coexistence: %s", err.Error())
+			resolver.EBPFBypassPolicyValue.Store(nil)
+			return
+		}
+		resolver.EBPFBypassPolicyValue.Store(&resolver.EBPFBypassPolicy{
+			Prefixes:  prefixes,
+			Set:       set,
+			TunDirect: i.bypassTUNDirect,
+		})
+	}
+	claimed := resolver.TunClaimedPrefixes(prefixes)
+	if len(claimed) == 0 {
+		return
+	}
+	i.tunOverlapWarnings.warn(
+		tunOverlapLogger(i.bypassTUNDirect),
+		resolver.TunBypassOverlapMessage(claimed, i.bypassTUNDirect),
+	)
+}
+
+// An overlap that is already handled on arrival is worth knowing about -- those
+// flows pay a userspace hop they were configured to skip -- but it is not a
+// misconfiguration, so it does not deserve a warning.
+func tunOverlapLogger(tunDirect bool) warningLogger {
+	if tunDirect {
+		return log.Infoln
+	}
+	return log.Warnln
+}
+
+func (i *Inbound) effectiveBypassPrefixesLocked() []netip.Prefix {
+	var prefixes []netip.Prefix
+	if i.bypassPrivateAddress {
+		prefixes = append(prefixes, ECommon.PrivateAddressPrefixes()...)
+	}
+	return append(prefixes, i.bypassCIDR...)
+}

--- a/listener/sing_ebpf/tun_coexist_test.go
+++ b/listener/sing_ebpf/tun_coexist_test.go
@@ -12,22 +12,25 @@ import (
 	"go4.org/netipx"
 )
 
-func restorePublishedPolicy(t *testing.T) {
+// testInbound builds the smallest Inbound that can publish a policy, with its
+// own registry slot removed when the test ends.
+func testInbound(t *testing.T, inbound *Inbound) *Inbound {
 	t.Helper()
-	policy := resolver.EBPFBypassPolicyValue.Load()
-	excludes := resolver.EBPFRouteExcludePrefixes.Load()
+	inbound.bypassPublisher = resolver.NewEBPFBypassPublisher()
+	inbound.tunOverlapWarnings.interval = tunOverlapWarningInterval
 	claim := resolver.TunRouteClaimed.Load()
 	t.Cleanup(func() {
-		resolver.EBPFBypassPolicyValue.Store(policy)
-		resolver.EBPFRouteExcludePrefixes.Store(excludes)
+		inbound.bypassPublisher.Close()
 		resolver.TunRouteClaimed.Store(claim)
 	})
+	return inbound
 }
 
 func TestPublishBypassPolicyPrivateAddress(t *testing.T) {
-	restorePublishedPolicy(t)
 	resolver.TunRouteClaimed.Store(nil)
-	inbound := &Inbound{bypassPrivateAddress: true}
+	// bypassTUNDirect mirrors the option default, which is what puts the
+	// prefixes into the membership set asserted below.
+	inbound := testInbound(t, &Inbound{bypassPrivateAddress: true, bypassTUNDirect: true})
 	inbound.publishBypassPolicyLocked()
 
 	excludes := resolver.EBPFRouteExcludePrefixes.Load()
@@ -41,7 +44,7 @@ func TestPublishBypassPolicyPrivateAddress(t *testing.T) {
 	if published == nil || len(published.Prefixes) != len(ECommon.PrivateAddressPrefixes()) {
 		t.Fatalf("expected the private set to be published as the policy, got %v", published)
 	}
-	if published.Set == nil || !published.Set.Contains(netip.MustParseAddr("192.168.1.1")) {
+	if published.DirectSet == nil || !published.DirectSet.Contains(netip.MustParseAddr("192.168.1.1")) {
 		t.Fatal("expected a usable membership set")
 	}
 }
@@ -50,10 +53,9 @@ func TestPublishBypassPolicyPrivateAddress(t *testing.T) {
 // route-exclude list: they resolve after the TUN device already baked its route
 // set, and a rule set can hold thousands of prefixes.
 func TestPublishBypassPolicyRuleSetIsNotRouteExcluded(t *testing.T) {
-	restorePublishedPolicy(t)
 	resolver.TunRouteClaimed.Store(nil)
 	ruleSetPrefix := netip.MustParsePrefix("203.0.113.0/24")
-	inbound := &Inbound{bypassCIDR: []netip.Prefix{ruleSetPrefix}}
+	inbound := testInbound(t, &Inbound{bypassCIDR: []netip.Prefix{ruleSetPrefix}})
 	inbound.publishBypassPolicyLocked()
 
 	if excludes := resolver.EBPFRouteExcludePrefixes.Load(); excludes != nil {
@@ -66,12 +68,14 @@ func TestPublishBypassPolicyRuleSetIsNotRouteExcluded(t *testing.T) {
 }
 
 func TestPublishBypassPolicyNothingBypassed(t *testing.T) {
-	restorePublishedPolicy(t)
-	stale := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
-	resolver.EBPFBypassPolicyValue.Store(&resolver.EBPFBypassPolicy{Prefixes: stale})
-	resolver.EBPFRouteExcludePrefixes.Store(&stale)
+	inbound := testInbound(t, &Inbound{bypassPrivateAddress: true, bypassTUNDirect: true})
+	inbound.publishBypassPolicyLocked()
+	if resolver.EBPFBypassPolicyValue.Load() == nil {
+		t.Fatal("expected a policy to be published first")
+	}
 
-	inbound := &Inbound{}
+	// Republishing with nothing to bypass must retract what this inbound had.
+	inbound.bypassPrivateAddress = false
 	inbound.publishBypassPolicyLocked()
 	if published := resolver.EBPFBypassPolicyValue.Load(); published != nil {
 		t.Fatalf("expected a stale policy to be cleared, got %v", published)
@@ -84,7 +88,6 @@ func TestPublishBypassPolicyNothingBypassed(t *testing.T) {
 // The whole point of the diagnostic: a bypassed prefix that TUN still routes is
 // not direct, so it has to be reported rather than silently black-holed.
 func TestPublishBypassPolicyReportsClaimedPrefixes(t *testing.T) {
-	restorePublishedPolicy(t)
 	var builder netipx.IPSetBuilder
 	builder.AddPrefix(netip.MustParsePrefix("0.0.0.0/0"))
 	claimed, err := builder.IPSet()
@@ -93,8 +96,7 @@ func TestPublishBypassPolicyReportsClaimedPrefixes(t *testing.T) {
 	}
 	resolver.TunRouteClaimed.Store(&resolver.TunRouteClaim{Claimed: claimed})
 
-	inbound := &Inbound{bypassCIDR: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}}
-	inbound.tunOverlapWarnings.interval = tunOverlapWarningInterval
+	inbound := testInbound(t, &Inbound{bypassCIDR: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}})
 
 	var warnings []string
 	logged := func(format string, args ...any) {

--- a/listener/sing_ebpf/tun_coexist_test.go
+++ b/listener/sing_ebpf/tun_coexist_test.go
@@ -1,0 +1,115 @@
+//go:build with_ebpf && (linux || android)
+
+package sing_ebpf
+
+import (
+	"net/netip"
+	"testing"
+
+	ECommon "github.com/metacubex/mihomo/common/ebpf"
+	"github.com/metacubex/mihomo/component/resolver"
+
+	"go4.org/netipx"
+)
+
+func restorePublishedPolicy(t *testing.T) {
+	t.Helper()
+	policy := resolver.EBPFBypassPolicyValue.Load()
+	excludes := resolver.EBPFRouteExcludePrefixes.Load()
+	claim := resolver.TunRouteClaimed.Load()
+	t.Cleanup(func() {
+		resolver.EBPFBypassPolicyValue.Store(policy)
+		resolver.EBPFRouteExcludePrefixes.Store(excludes)
+		resolver.TunRouteClaimed.Store(claim)
+	})
+}
+
+func TestPublishBypassPolicyPrivateAddress(t *testing.T) {
+	restorePublishedPolicy(t)
+	resolver.TunRouteClaimed.Store(nil)
+	inbound := &Inbound{bypassPrivateAddress: true}
+	inbound.publishBypassPolicyLocked()
+
+	excludes := resolver.EBPFRouteExcludePrefixes.Load()
+	if excludes == nil {
+		t.Fatal("expected the private ranges to be offered for route exclusion")
+	}
+	if len(*excludes) != len(ECommon.PrivateAddressPrefixes()) {
+		t.Fatalf("expected the whole private set, got %v", *excludes)
+	}
+	published := resolver.EBPFBypassPolicyValue.Load()
+	if published == nil || len(published.Prefixes) != len(ECommon.PrivateAddressPrefixes()) {
+		t.Fatalf("expected the private set to be published as the policy, got %v", published)
+	}
+	if published.Set == nil || !published.Set.Contains(netip.MustParseAddr("192.168.1.1")) {
+		t.Fatal("expected a usable membership set")
+	}
+}
+
+// bypass_rule_set CIDRs belong in the reported policy but must never reach the
+// route-exclude list: they resolve after the TUN device already baked its route
+// set, and a rule set can hold thousands of prefixes.
+func TestPublishBypassPolicyRuleSetIsNotRouteExcluded(t *testing.T) {
+	restorePublishedPolicy(t)
+	resolver.TunRouteClaimed.Store(nil)
+	ruleSetPrefix := netip.MustParsePrefix("203.0.113.0/24")
+	inbound := &Inbound{bypassCIDR: []netip.Prefix{ruleSetPrefix}}
+	inbound.publishBypassPolicyLocked()
+
+	if excludes := resolver.EBPFRouteExcludePrefixes.Load(); excludes != nil {
+		t.Fatalf("expected no route exclusion without private bypass, got %v", *excludes)
+	}
+	published := resolver.EBPFBypassPolicyValue.Load()
+	if published == nil || len(published.Prefixes) != 1 || published.Prefixes[0] != ruleSetPrefix {
+		t.Fatalf("expected the rule-set prefix to be published, got %v", published)
+	}
+}
+
+func TestPublishBypassPolicyNothingBypassed(t *testing.T) {
+	restorePublishedPolicy(t)
+	stale := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	resolver.EBPFBypassPolicyValue.Store(&resolver.EBPFBypassPolicy{Prefixes: stale})
+	resolver.EBPFRouteExcludePrefixes.Store(&stale)
+
+	inbound := &Inbound{}
+	inbound.publishBypassPolicyLocked()
+	if published := resolver.EBPFBypassPolicyValue.Load(); published != nil {
+		t.Fatalf("expected a stale policy to be cleared, got %v", published)
+	}
+	if excludes := resolver.EBPFRouteExcludePrefixes.Load(); excludes != nil {
+		t.Fatalf("expected stale route exclusions to be cleared, got %v", *excludes)
+	}
+}
+
+// The whole point of the diagnostic: a bypassed prefix that TUN still routes is
+// not direct, so it has to be reported rather than silently black-holed.
+func TestPublishBypassPolicyReportsClaimedPrefixes(t *testing.T) {
+	restorePublishedPolicy(t)
+	var builder netipx.IPSetBuilder
+	builder.AddPrefix(netip.MustParsePrefix("0.0.0.0/0"))
+	claimed, err := builder.IPSet()
+	if err != nil {
+		t.Fatalf("build set: %s", err)
+	}
+	resolver.TunRouteClaimed.Store(&resolver.TunRouteClaim{Claimed: claimed})
+
+	inbound := &Inbound{bypassCIDR: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}}
+	inbound.tunOverlapWarnings.interval = tunOverlapWarningInterval
+
+	var warnings []string
+	logged := func(format string, args ...any) {
+		warnings = append(warnings, format)
+	}
+	inbound.publishBypassPolicyLocked()
+	// publishBypassPolicyLocked logs through the package logger; re-run the
+	// limiter directly to prove the overlap is what gets reported and that the
+	// interval keeps it from repeating.
+	overlap := resolver.TunClaimedBypassPrefixes()
+	if len(overlap) != 1 || overlap[0] != netip.MustParsePrefix("203.0.113.0/24") {
+		t.Fatalf("expected the claimed bypass prefix to be reported, got %v", overlap)
+	}
+	inbound.tunOverlapWarnings.warn(logged, resolver.TunBypassOverlapMessage(overlap, false))
+	if len(warnings) != 0 {
+		t.Fatalf("expected the first report to have consumed the interval, got %v", warnings)
+	}
+}

--- a/listener/sing_tun/ebpf_coexist.go
+++ b/listener/sing_tun/ebpf_coexist.go
@@ -1,0 +1,117 @@
+package sing_tun
+
+import (
+	"net/netip"
+	"strings"
+
+	"github.com/metacubex/mihomo/component/resolver"
+	"github.com/metacubex/mihomo/log"
+
+	tun "github.com/metacubex/sing-tun"
+
+	"go4.org/netipx"
+)
+
+// ebpfRouteExcludeAddress returns the extra route-exclude prefixes a running
+// eBPF inbound needs.
+//
+// The eBPF inbound bypasses a destination at the socket layer, which only means
+// the socket keeps its original destination. The packet still follows the
+// routing table, and auto-route points that table at this device, so without
+// these exclusions every bypassed destination lands in TUN anyway and is routed
+// by the rules -- a black hole for any destination the rules hand to a proxy
+// that cannot reach it. Keeping the prefixes off the routes is what makes the
+// bypass an actual direct connection.
+//
+// Only what the eBPF inbound published is excluded, so a config that carries an
+// eBPF listener the kernel then refused to load does not silently change how
+// TUN routes traffic.
+func ebpfRouteExcludeAddress(tunAddressSets ...[]netip.Prefix) []netip.Prefix {
+	published := resolver.EBPFRouteExcludePrefixes.Load()
+	if published == nil || len(*published) == 0 {
+		return nil
+	}
+	var builder netipx.IPSetBuilder
+	for _, prefix := range *published {
+		builder.AddPrefix(prefix)
+	}
+	// A fake-ip range that lands inside a bypassed range stays on the routes: a
+	// fake address means nothing to the kernel, and the eBPF program forces
+	// interception for it instead of bypassing it.
+	fakeIPv4, fakeIPv6 := resolver.FakeIPRanges()
+	removePrefix(&builder, fakeIPv4, fakeIPv6)
+	// The device also has to keep reaching its own addresses.
+	for _, prefixes := range tunAddressSets {
+		removePrefix(&builder, prefixes...)
+	}
+	excluded, err := builder.IPSet()
+	if err != nil || excluded == nil {
+		return nil
+	}
+	return excluded.Prefixes()
+}
+
+func removePrefix(builder *netipx.IPSetBuilder, prefixes ...netip.Prefix) {
+	for _, prefix := range prefixes {
+		// An invalid prefix would be recorded as a builder error and discard the
+		// whole set, so unset optional ranges have to be skipped here.
+		if prefix.IsValid() {
+			builder.RemovePrefix(prefix)
+		}
+	}
+}
+
+// publishTunRouteClaim records which destinations this listener took over, so
+// the eBPF inbound can report the bypassed prefixes that will not be direct
+// after all. The claim is the final route set, after every route-exclude option
+// has been applied.
+func publishTunRouteClaim(tunOptions *tun.Options) {
+	if !tunOptions.AutoRoute {
+		resolver.TunRouteClaimed.Store(nil)
+		return
+	}
+	routeRanges, err := tunOptions.BuildAutoRouteRanges(false)
+	if err != nil || len(routeRanges) == 0 {
+		resolver.TunRouteClaimed.Store(nil)
+		return
+	}
+	var builder netipx.IPSetBuilder
+	for _, prefix := range routeRanges {
+		builder.AddPrefix(prefix)
+	}
+	claimed, err := builder.IPSet()
+	if err != nil {
+		resolver.TunRouteClaimed.Store(nil)
+		return
+	}
+	resolver.TunRouteClaimed.Store(&resolver.TunRouteClaim{Claimed: claimed})
+	// The eBPF inbound starts before this listener, so it cannot see the claim
+	// when it publishes its own policy. Report from this side too, otherwise an
+	// overlap that never changes again is never reported at all.
+	overlap := resolver.TunClaimedBypassPrefixes()
+	if len(overlap) == 0 {
+		return
+	}
+	tunDirect := false
+	if policy := resolver.EBPFBypassPolicyValue.Load(); policy != nil {
+		tunDirect = policy.TunDirect
+	}
+	message := resolver.TunBypassOverlapMessage(overlap, tunDirect)
+	if tunDirect {
+		log.Infoln("[TUN] %s", message)
+	} else {
+		log.Warnln("[TUN] %s", message)
+	}
+}
+
+func clearTunRouteClaim() {
+	resolver.TunRouteClaimed.Store(nil)
+}
+
+func prefixesText(prefixes []netip.Prefix) string {
+	texts := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		texts = append(texts, prefix.String())
+	}
+	return strings.Join(texts, ", ")
+}

--- a/listener/sing_tun/ebpf_coexist_test.go
+++ b/listener/sing_tun/ebpf_coexist_test.go
@@ -1,0 +1,160 @@
+package sing_tun
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/metacubex/mihomo/component/resolver"
+
+	tun "github.com/metacubex/sing-tun"
+
+	"go4.org/netipx"
+)
+
+func restoreCoexistState(t *testing.T) {
+	t.Helper()
+	excludes := resolver.EBPFRouteExcludePrefixes.Load()
+	claim := resolver.TunRouteClaimed.Load()
+	policy := resolver.EBPFBypassPolicyValue.Load()
+	ipv4, ipv6 := resolver.FakeIPRanges()
+	t.Cleanup(func() {
+		resolver.EBPFRouteExcludePrefixes.Store(excludes)
+		resolver.TunRouteClaimed.Store(claim)
+		resolver.EBPFBypassPolicyValue.Store(policy)
+		resolver.StoreFakeIPRanges(ipv4, ipv6)
+	})
+}
+
+func publishExcludes(prefixes ...string) {
+	parsed := make([]netip.Prefix, 0, len(prefixes))
+	for _, text := range prefixes {
+		parsed = append(parsed, netip.MustParsePrefix(text))
+	}
+	resolver.EBPFRouteExcludePrefixes.Store(&parsed)
+}
+
+func prefixTexts(prefixes []netip.Prefix) []string {
+	texts := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		texts = append(texts, prefix.String())
+	}
+	return texts
+}
+
+// Nothing published means no eBPF inbound is running with a bypass policy, and
+// TUN must then route exactly what it was configured to route. A config that
+// carries an eBPF listener the kernel refused to load must not quietly change
+// how traffic is routed.
+func TestEBPFRouteExcludeAddressNothingPublished(t *testing.T) {
+	restoreCoexistState(t)
+	resolver.EBPFRouteExcludePrefixes.Store(nil)
+	resolver.StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
+	if excluded := ebpfRouteExcludeAddress(nil, nil); excluded != nil {
+		t.Fatalf("expected no exclusions, got %v", excluded)
+	}
+	empty := []netip.Prefix{}
+	resolver.EBPFRouteExcludePrefixes.Store(&empty)
+	if excluded := ebpfRouteExcludeAddress(nil, nil); excluded != nil {
+		t.Fatalf("expected no exclusions for an empty policy, got %v", excluded)
+	}
+}
+
+func TestEBPFRouteExcludeAddressPassesPolicyThrough(t *testing.T) {
+	restoreCoexistState(t)
+	publishExcludes("10.0.0.0/8", "192.168.0.0/16")
+	resolver.StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
+	texts := prefixTexts(ebpfRouteExcludeAddress(nil, nil))
+	if len(texts) != 2 || texts[0] != "10.0.0.0/8" || texts[1] != "192.168.0.0/16" {
+		t.Fatalf("expected both prefixes, got %v", texts)
+	}
+}
+
+// A fake-ip range inside a bypassed range has to stay on the TUN routes: the
+// address only means something to mihomo, and the eBPF program forces
+// interception for it rather than bypassing it.
+func TestEBPFRouteExcludeAddressKeepsFakeIPRange(t *testing.T) {
+	restoreCoexistState(t)
+	publishExcludes("100.64.0.0/10")
+	resolver.StoreFakeIPRanges(netip.MustParsePrefix("100.64.0.0/16"), netip.Prefix{})
+	texts := prefixTexts(ebpfRouteExcludeAddress(nil, nil))
+	for _, text := range texts {
+		if text == "100.64.0.0/10" || text == "100.64.0.0/16" {
+			t.Fatalf("fake-ip range was excluded from the routes: %v", texts)
+		}
+	}
+	if len(texts) == 0 {
+		t.Fatal("expected the rest of the bypassed range to stay excluded")
+	}
+	// The hole must be exactly the fake-ip range: 100.65.0.0 is still bypassed.
+	var covered bool
+	for _, prefix := range ebpfRouteExcludeAddress(nil, nil) {
+		if prefix.Contains(netip.MustParseAddr("100.65.0.1")) {
+			covered = true
+		}
+	}
+	if !covered {
+		t.Fatalf("expected the non-fake part to stay excluded, got %v", texts)
+	}
+}
+
+func TestEBPFRouteExcludeAddressKeepsTunAddresses(t *testing.T) {
+	restoreCoexistState(t)
+	publishExcludes("fc00::/7")
+	resolver.StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
+	tunIPv6 := []netip.Prefix{netip.MustParsePrefix("fdfe:dcba:9876::1/126")}
+	for _, prefix := range ebpfRouteExcludeAddress(nil, tunIPv6) {
+		if prefix.Contains(netip.MustParseAddr("fdfe:dcba:9876::1")) {
+			t.Fatalf("the device's own address was excluded from its routes: %s", prefix)
+		}
+	}
+}
+
+func TestPublishTunRouteClaim(t *testing.T) {
+	restoreCoexistState(t)
+	bypassed := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8"), netip.MustParsePrefix("198.51.100.0/24")}
+	var builder netipx.IPSetBuilder
+	for _, prefix := range bypassed {
+		builder.AddPrefix(prefix)
+	}
+	bypassSet, err := builder.IPSet()
+	if err != nil {
+		t.Fatalf("build set: %s", err)
+	}
+	resolver.EBPFBypassPolicyValue.Store(&resolver.EBPFBypassPolicy{
+		Prefixes: bypassed, Set: bypassSet, TunDirect: true,
+	})
+
+	// No auto-route: nothing is taken over, so a bypass reaches the routing
+	// table untouched.
+	publishTunRouteClaim(&tun.Options{
+		Inet4Address: []netip.Prefix{netip.MustParsePrefix("198.18.0.1/30")},
+	})
+	if claim := resolver.TunRouteClaimed.Load(); claim != nil {
+		t.Fatalf("expected no claim without auto-route, got %v", claim)
+	}
+
+	publishTunRouteClaim(&tun.Options{
+		AutoRoute:                true,
+		Inet4Address:             []netip.Prefix{netip.MustParsePrefix("198.18.0.1/30")},
+		Inet4RouteExcludeAddress: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+	})
+	claim := resolver.TunRouteClaimed.Load()
+	if claim == nil || claim.Claimed == nil {
+		t.Fatal("expected a published claim")
+	}
+	if claim.Claimed.Contains(netip.MustParseAddr("10.1.2.3")) {
+		t.Fatal("expected the excluded prefix to be off the claim")
+	}
+	if !claim.Claimed.Contains(netip.MustParseAddr("198.51.100.7")) {
+		t.Fatal("expected everything else to stay claimed")
+	}
+	overlap := prefixTexts(resolver.TunClaimedBypassPrefixes())
+	if len(overlap) != 1 || overlap[0] != "198.51.100.0/24" {
+		t.Fatalf("expected only the still-routed bypass prefix to be reported, got %v", overlap)
+	}
+
+	clearTunRouteClaim()
+	if claim := resolver.TunRouteClaimed.Load(); claim != nil {
+		t.Fatalf("expected the claim to be cleared, got %v", claim)
+	}
+}

--- a/listener/sing_tun/ebpf_coexist_test.go
+++ b/listener/sing_tun/ebpf_coexist_test.go
@@ -7,30 +7,27 @@ import (
 	"github.com/metacubex/mihomo/component/resolver"
 
 	tun "github.com/metacubex/sing-tun"
-
-	"go4.org/netipx"
 )
 
-func restoreCoexistState(t *testing.T) {
+func restoreCoexistState(t *testing.T) *resolver.EBPFBypassPublisher {
 	t.Helper()
-	excludes := resolver.EBPFRouteExcludePrefixes.Load()
 	claim := resolver.TunRouteClaimed.Load()
-	policy := resolver.EBPFBypassPolicyValue.Load()
 	ipv4, ipv6 := resolver.FakeIPRanges()
+	publisher := resolver.NewEBPFBypassPublisher()
 	t.Cleanup(func() {
-		resolver.EBPFRouteExcludePrefixes.Store(excludes)
+		publisher.Close()
 		resolver.TunRouteClaimed.Store(claim)
-		resolver.EBPFBypassPolicyValue.Store(policy)
 		resolver.StoreFakeIPRanges(ipv4, ipv6)
 	})
+	return publisher
 }
 
-func publishExcludes(prefixes ...string) {
+func publishExcludes(publisher *resolver.EBPFBypassPublisher, prefixes ...string) {
 	parsed := make([]netip.Prefix, 0, len(prefixes))
 	for _, text := range prefixes {
 		parsed = append(parsed, netip.MustParsePrefix(text))
 	}
-	resolver.EBPFRouteExcludePrefixes.Store(&parsed)
+	publisher.Publish(nil, parsed, parsed, true)
 }
 
 func prefixTexts(prefixes []netip.Prefix) []string {
@@ -46,22 +43,20 @@ func prefixTexts(prefixes []netip.Prefix) []string {
 // carries an eBPF listener the kernel refused to load must not quietly change
 // how traffic is routed.
 func TestEBPFRouteExcludeAddressNothingPublished(t *testing.T) {
-	restoreCoexistState(t)
-	resolver.EBPFRouteExcludePrefixes.Store(nil)
+	publisher := restoreCoexistState(t)
 	resolver.StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
 	if excluded := ebpfRouteExcludeAddress(nil, nil); excluded != nil {
 		t.Fatalf("expected no exclusions, got %v", excluded)
 	}
-	empty := []netip.Prefix{}
-	resolver.EBPFRouteExcludePrefixes.Store(&empty)
+	// An inbound that bypasses nothing publishes nothing to exclude.
+	publisher.Publish(nil, nil, nil, true)
 	if excluded := ebpfRouteExcludeAddress(nil, nil); excluded != nil {
 		t.Fatalf("expected no exclusions for an empty policy, got %v", excluded)
 	}
 }
 
 func TestEBPFRouteExcludeAddressPassesPolicyThrough(t *testing.T) {
-	restoreCoexistState(t)
-	publishExcludes("10.0.0.0/8", "192.168.0.0/16")
+	publishExcludes(restoreCoexistState(t), "10.0.0.0/8", "192.168.0.0/16")
 	resolver.StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
 	texts := prefixTexts(ebpfRouteExcludeAddress(nil, nil))
 	if len(texts) != 2 || texts[0] != "10.0.0.0/8" || texts[1] != "192.168.0.0/16" {
@@ -73,8 +68,7 @@ func TestEBPFRouteExcludeAddressPassesPolicyThrough(t *testing.T) {
 // address only means something to mihomo, and the eBPF program forces
 // interception for it rather than bypassing it.
 func TestEBPFRouteExcludeAddressKeepsFakeIPRange(t *testing.T) {
-	restoreCoexistState(t)
-	publishExcludes("100.64.0.0/10")
+	publishExcludes(restoreCoexistState(t), "100.64.0.0/10")
 	resolver.StoreFakeIPRanges(netip.MustParsePrefix("100.64.0.0/16"), netip.Prefix{})
 	texts := prefixTexts(ebpfRouteExcludeAddress(nil, nil))
 	for _, text := range texts {
@@ -98,8 +92,7 @@ func TestEBPFRouteExcludeAddressKeepsFakeIPRange(t *testing.T) {
 }
 
 func TestEBPFRouteExcludeAddressKeepsTunAddresses(t *testing.T) {
-	restoreCoexistState(t)
-	publishExcludes("fc00::/7")
+	publishExcludes(restoreCoexistState(t), "fc00::/7")
 	resolver.StoreFakeIPRanges(netip.Prefix{}, netip.Prefix{})
 	tunIPv6 := []netip.Prefix{netip.MustParsePrefix("fdfe:dcba:9876::1/126")}
 	for _, prefix := range ebpfRouteExcludeAddress(nil, tunIPv6) {
@@ -110,19 +103,11 @@ func TestEBPFRouteExcludeAddressKeepsTunAddresses(t *testing.T) {
 }
 
 func TestPublishTunRouteClaim(t *testing.T) {
-	restoreCoexistState(t)
-	bypassed := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8"), netip.MustParsePrefix("198.51.100.0/24")}
-	var builder netipx.IPSetBuilder
-	for _, prefix := range bypassed {
-		builder.AddPrefix(prefix)
-	}
-	bypassSet, err := builder.IPSet()
-	if err != nil {
-		t.Fatalf("build set: %s", err)
-	}
-	resolver.EBPFBypassPolicyValue.Store(&resolver.EBPFBypassPolicy{
-		Prefixes: bypassed, Set: bypassSet, TunDirect: true,
-	})
+	publisher := restoreCoexistState(t)
+	publisher.Publish(nil, []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("198.51.100.0/24"),
+	}, nil, true)
 
 	// No auto-route: nothing is taken over, so a bypass reaches the routing
 	// table untouched.

--- a/listener/sing_tun/server.go
+++ b/listener/sing_tun/server.go
@@ -183,6 +183,11 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 	if len(options.Inet6RouteExcludeAddress) > 0 {
 		routeExcludeAddress = append(routeExcludeAddress, options.Inet6RouteExcludeAddress...)
 	}
+	if ebpfExclude := ebpfRouteExcludeAddress(options.Inet4Address, options.Inet6Address); len(ebpfExclude) > 0 {
+		routeExcludeAddress = append(routeExcludeAddress, ebpfExclude...)
+		log.Infoln("[TUN] keeping %d prefix(es) off auto-route so the eBPF inbound bypass stays direct: %s",
+			len(ebpfExclude), prefixesText(ebpfExclude))
+	}
 	inet4RouteExcludeAddress := common.Filter(routeExcludeAddress, func(it netip.Prefix) bool {
 		return it.Addr().Is4()
 	})
@@ -538,6 +543,8 @@ func New(options LC.Tun, tunnel C.Tunnel, additions ...inbound.Addition) (l *Lis
 		resolver.ResetConnection()
 	}
 
+	publishTunRouteClaim(&tunOptions)
+
 	if options.FileDescriptor != 0 {
 		tunName = fmt.Sprintf("%s(fd=%d)", tunName, options.FileDescriptor)
 	}
@@ -667,6 +674,7 @@ func parseRange[T constraints.Integer](uidRanges []ranges.Range[T], rangeList []
 
 func (l *Listener) Close() error {
 	l.closed = true
+	clearTunRouteClaim()
 	resolver.RemoveSystemDnsBlacklist(l.dnsServerIp...)
 	if l.autoRedirectOutputMark != 0 {
 		dialer.DefaultRoutingMark.CompareAndSwap(l.autoRedirectOutputMark, 0)

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -285,6 +285,35 @@ func fixMetadata(metadata *C.Metadata) {
 	}
 }
 
+// ebpfBypassedDirect honours an eBPF bypass that TUN took over.
+//
+// A destination the eBPF inbound bypasses is one the kernel already let past
+// the redirect; it only arrives here because TUN auto-route pointed the routing
+// table at the TUN device. Matching it against the rules is what turns the
+// bypass into a black hole: the rules were written expecting these destinations
+// never to arrive, so they fall through to the final rule, and a LAN or
+// geo-restricted address handed to a remote proxy simply times out. Connecting
+// it directly is what the bypass asked for in the first place.
+//
+// Only TUN-sourced flows qualify. Every other inbound was addressed on purpose,
+// so its traffic is the user's explicit request to route something, not a side
+// effect of a route the eBPF policy tried to leave alone.
+func ebpfBypassedDirect(metadata *C.Metadata) (C.Proxy, bool) {
+	if metadata.Type != C.TUN || !metadata.DstIP.IsValid() {
+		return nil, false
+	}
+	if !resolver.EBPFBypassedDirect(metadata.DstIP) {
+		return nil, false
+	}
+	direct, exist := proxies["DIRECT"]
+	if !exist {
+		return nil, false
+	}
+	log.Debugln("[Rule] %s is bypassed by the eBPF inbound, connecting directly instead of matching rules",
+		metadata.RemoteAddress())
+	return direct, true
+}
+
 func needLookupIP(metadata *C.Metadata) bool {
 	return resolver.MappingEnabled() && metadata.Host == "" && metadata.DstIP.IsValid()
 }
@@ -325,6 +354,9 @@ func resolveMetadata(metadata *C.Metadata) (proxy C.Proxy, rule C.Rule, err erro
 			err = fmt.Errorf("proxy %s not found", metadata.SpecialProxy)
 		}
 		return
+	}
+	if direct, ok := ebpfBypassedDirect(metadata); ok {
+		return direct, nil, nil
 	}
 	var (
 		resolved             bool


### PR DESCRIPTION
## Summary

This PR enables eBPF and TUN listeners to coexist by implementing intelligent route exclusion and bypass policy coordination. Previously, these two mechanisms conflicted because eBPF bypasses operate at the socket layer while TUN's auto-route controls the routing table, causing bypassed destinations to still be routed through TUN. The solution splits handling by set size: fixed private ranges use route exclusion, while larger bypass_rule_sets use direct connection matching on arrival.

## Key Changes

- **Fake-IP range tracking**: Added `StoreFakeIPRanges()` and `RegisterFakeIPRangeObserver()` to publish active fake-IP ranges to kernel eBPF programs, ensuring fake addresses are always intercepted even when inside bypassed ranges (e.g., 100.64.0.0/10)

- **eBPF bypass policy publishing**: Introduced `EBPFBypassPolicy` struct and `EBPFBypassPolicyValue` atomic to publish the effective bypass policy (private ranges + rule-set CIDRs) with membership test support via `IPSet`

- **TUN route claiming**: Added `TunRouteClaim` and `TunRouteClaimed` to track which destinations TUN has taken over via auto-route, enabling overlap detection and reporting

- **Route exclusion coordination**: Implemented `ebpfRouteExcludeAddress()` to compute which prefixes TUN must exclude from its routes, removing fake-IP ranges and TUN's own addresses from the exclusion set

- **Direct bypass handling**: Added `EBPFBypassedDirect()` to honor eBPF bypasses for destinations TUN claimed, preventing them from being black-holed by the rule engine

- **Overlap detection and reporting**: Implemented `TunClaimedBypassPrefixes()` and `TunBypassOverlapMessage()` to identify and report when bypassed destinations are still claimed by TUN routes

- **Kernel integration**: Added `SetFakeIPRanges()` methods to both `CgroupBackend` and `SharedNetworkBackend` to update kernel control records at runtime

- **Network monitoring**: Implemented `localNetworkMonitor` to keep host address policies synchronized with interface changes

- **Comprehensive test coverage**: Added extensive tests for all new components including fake-IP range tracking, bypass policy publishing, route exclusion logic, and coexistence scenarios

## Implementation Details

- Fake-IP ranges are published via observer pattern to both local cgroup and shared TC backends
- Route exclusion uses `netipx.IPSetBuilder` to compute set differences, removing fake-IP and TUN address ranges from the bypass policy
- Overlap warnings are rate-limited to 10 minutes to avoid spam for configuration conditions
- The solution preserves backward compatibility: configs without eBPF or TUN work unchanged
- Documentation updated to explain the coexistence mechanism and configuration requirements

https://claude.ai/code/session_01C9qefHwxMvA3wdfaTaXAXY